### PR TITLE
Use only WGS84 valid coordinates for Observation Storage unit test

### DIFF
--- a/sensorhub-core/src/test/java/org/sensorhub/test/persistence/AbstractTestObsStorage.java
+++ b/sensorhub-core/src/test/java/org/sensorhub/test/persistence/AbstractTestObsStorage.java
@@ -602,6 +602,7 @@ public abstract class AbstractTestObsStorage<StorageType extends IObsStorageModu
         Bbox realExtent = new Bbox();
         addFoisToStorage(realExtent);
         Bbox foiExtent = storage.getFoisSpatialExtent();
-        assertEquals("Wrong FOI spatial extent", realExtent, foiExtent);
+        // Storage bounding box may be larger than real extent, but not smaller (rounding)
+        assertTrue("Wrong FOI spatial extent", foiExtent.contains(realExtent));
     }
 }

--- a/sensorhub-core/src/test/java/org/sensorhub/test/persistence/AbstractTestObsStorage.java
+++ b/sensorhub-core/src/test/java/org/sensorhub/test/persistence/AbstractTestObsStorage.java
@@ -594,6 +594,28 @@ public abstract class AbstractTestObsStorage<StorageType extends IObsStorageModu
         filter = buildFilterByRoi(recordDef, testList, roi);
         checkFilteredResults(filter, testList);
     }
+
+    public boolean bboxContains(Bbox a, Bbox bbox, double epsilon) {
+
+        double bboxX1 = bbox.getMinX();
+        double bboxX2 = bbox.getMaxX();
+        double bboxY1 = bbox.getMinY();
+        double bboxY2 = bbox.getMaxY();
+
+        if ( a.getMinX() - bboxX1 > epsilon || bboxX1 - a.getMaxX() > epsilon)
+            return false;
+
+        if ( a.getMinX() - bboxX2 > epsilon  || bboxX2 - a.getMaxX() > epsilon)
+            return false;
+
+        if (a.getMinY() - bboxY1 > epsilon  || bboxY1 - a.getMaxY() > epsilon)
+            return false;
+
+        if (a.getMinY() - bboxY2 > epsilon  || bboxY2 - a.getMaxY() > epsilon)
+            return false;
+
+        return true;
+    }
     
     
     @Test
@@ -603,6 +625,6 @@ public abstract class AbstractTestObsStorage<StorageType extends IObsStorageModu
         addFoisToStorage(realExtent);
         Bbox foiExtent = storage.getFoisSpatialExtent();
         // Storage bounding box may be larger than real extent, but not smaller (rounding)
-        assertTrue("Wrong FOI spatial extent", foiExtent.contains(realExtent));
+        assertTrue("Wrong FOI spatial extent", bboxContains(foiExtent, realExtent, 1e-6));
     }
 }

--- a/sensorhub-core/src/test/java/org/sensorhub/test/persistence/AbstractTestObsStorage.java
+++ b/sensorhub-core/src/test/java/org/sensorhub/test/persistence/AbstractTestObsStorage.java
@@ -17,7 +17,14 @@ package org.sensorhub.test.persistence;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import javax.xml.namespace.QName;
 import net.opengis.gml.v32.AbstractFeature;
 import net.opengis.gml.v32.Point;
@@ -39,7 +46,6 @@ import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.Polygon;
-import org.vast.util.SpatialExtent;
 
 
 /**

--- a/sensorhub-core/src/test/java/org/sensorhub/test/persistence/AbstractTestObsStorage.java
+++ b/sensorhub-core/src/test/java/org/sensorhub/test/persistence/AbstractTestObsStorage.java
@@ -39,6 +39,7 @@ import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.Polygon;
+import org.vast.util.SpatialExtent;
 
 
 /**
@@ -85,7 +86,7 @@ public abstract class AbstractTestObsStorage<StorageType extends IObsStorageModu
     int[] FOI_STARTS = FOI_SET1_STARTS;
     
     
-    protected void addFoisToStorage() throws Exception
+    protected void addFoisToStorage(Bbox extent) throws Exception
     {
         allFeatures = new LinkedHashMap<String, AbstractFeature>(numFois);
         
@@ -100,6 +101,9 @@ public abstract class AbstractTestObsStorage<StorageType extends IObsStorageModu
             Point p = gmlFac.newPoint();
             p.setPos(new double[] {interpolate(foiNum, numFois, longitudeBounds),
                     interpolate(foiNum, numFois, latitudeBounds), 0.0});
+            if(extent != null) {
+                extent.add(new Bbox(p.getPos()[0],p.getPos()[1], 0,p.getPos()[0],p.getPos()[1], 0));
+            }
             foi.setLocation(p);
             allFeatures.put(foi.getUniqueIdentifier(), foi);
             storage.storeFoi(producerID, foi);
@@ -113,7 +117,7 @@ public abstract class AbstractTestObsStorage<StorageType extends IObsStorageModu
     @Test
     public void testStoreAndRetrieveFoisByID() throws Exception
     {
-        addFoisToStorage();
+        addFoisToStorage(null);
         testFilterFoiByID(1, 2, 3, 22, 50, 78);
         testFilterFoiByID(1);
         testFilterFoiByID(56);
@@ -127,7 +131,7 @@ public abstract class AbstractTestObsStorage<StorageType extends IObsStorageModu
     @Test
     public void testStoreAndRetrieveFoisWithWrongIDs() throws Exception
     {
-        addFoisToStorage();
+        addFoisToStorage(null);
         testFilterFoiByID(102);
         testFilterFoiByID(102, 56, 516);
         testFilterFoiByID(102, 103, 104, 56, 516, 5);
@@ -179,7 +183,7 @@ public abstract class AbstractTestObsStorage<StorageType extends IObsStorageModu
     @Test
     public void testStoreAndRetrieveFoisByRoi() throws Exception
     {
-        addFoisToStorage();
+        addFoisToStorage(null);
         
         for (int i = 1; i <= numFois; i++) {
             double x = interpolate(i, numFois, longitudeBounds);
@@ -522,7 +526,7 @@ public abstract class AbstractTestObsStorage<StorageType extends IObsStorageModu
     @Test
     public void testGetRecordsByRoi() throws Exception
     {
-        addFoisToStorage();
+        addFoisToStorage(null);
         
         DataComponent recordDef = createDs2();
         List<DataBlock> dataList = addObservationsWithFoiToStorage(recordDef);
@@ -589,8 +593,8 @@ public abstract class AbstractTestObsStorage<StorageType extends IObsStorageModu
     @Test
     public void testGetFoiExtent() throws Exception
     {
-        addFoisToStorage();        
-        Bbox realExtent = new Bbox(1.0, 1.0, 0, numFois, numFois, 0);
+        Bbox realExtent = new Bbox();
+        addFoisToStorage(realExtent);
         Bbox foiExtent = storage.getFoisSpatialExtent();
         assertEquals("Wrong FOI spatial extent", realExtent, foiExtent);
     }

--- a/sensorhub-core/src/test/java/org/sensorhub/test/persistence/AbstractTestObsStorage.java
+++ b/sensorhub-core/src/test/java/org/sensorhub/test/persistence/AbstractTestObsStorage.java
@@ -16,14 +16,8 @@ package org.sensorhub.test.persistence;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+
+import java.util.*;
 import javax.xml.namespace.QName;
 import net.opengis.gml.v32.AbstractFeature;
 import net.opengis.gml.v32.Point;
@@ -64,6 +58,16 @@ public abstract class AbstractTestObsStorage<StorageType extends IObsStorageModu
     protected int numFois = 100;
     GMLFactory gmlFac = new GMLFactory(true);
     Map<String, AbstractFeature> allFeatures;
+
+
+    static final double[] longitudeBounds = new double[] {-170, 170, 340};
+    static final double[] latitudeBounds = new double[] {-80, 80, 160};
+
+    static double interpolate(double val, double max, double[] bounds) {
+        return (val / max) * bounds[2] + bounds[0];
+    }
+
+
     
     static String[] FOI_SET1_IDS = new String[]
     {
@@ -94,7 +98,8 @@ public abstract class AbstractTestObsStorage<StorageType extends IObsStorageModu
             foi.setName("FOI" + foiNum);
             foi.setDescription("This is feature of interest #" + foiNum);                        
             Point p = gmlFac.newPoint();
-            p.setPos(new double[] {foiNum, foiNum, 0.0});
+            p.setPos(new double[] {interpolate(foiNum, numFois, longitudeBounds),
+                    interpolate(foiNum, numFois, latitudeBounds), 0.0});
             foi.setLocation(p);
             allFeatures.put(foi.getUniqueIdentifier(), foi);
             storage.storeFoi(producerID, foi);
@@ -176,8 +181,11 @@ public abstract class AbstractTestObsStorage<StorageType extends IObsStorageModu
     {
         addFoisToStorage();
         
-        for (int i = 1; i <= numFois; i++)
-            testFilterFoiByRoi(new Bbox(i-0.5, i-0.5, i+0.5, i+0.5), i);
+        for (int i = 1; i <= numFois; i++) {
+            double x = interpolate(i, numFois, longitudeBounds);
+            double y = interpolate(i, numFois, latitudeBounds);
+            testFilterFoiByRoi(new Bbox(x - 0.5, y - 0.5, x + 0.5, y + 0.5), i);
+        }
     }
     
     


### PR DESCRIPTION
Some spatial storage (like elastic search) handle only valid WGS84 coordinates.
