### PR TITLE
initialize excludeOutputs

### DIFF
--- a/sensorhub-core/src/main/java/org/sensorhub/impl/persistence/StreamStorageConfig.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/persistence/StreamStorageConfig.java
@@ -14,6 +14,7 @@ Copyright (C) 2012-2015 Sensia Software LLC. All Rights Reserved.
 
 package org.sensorhub.impl.persistence;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.sensorhub.api.config.DisplayInfo;
 import org.sensorhub.api.config.DisplayInfo.Required;
@@ -34,7 +35,7 @@ public class StreamStorageConfig extends StorageConfig
     
     
     @DisplayInfo(desc="Names of data source outputs that should not be saved to storage")
-    public List<String> excludedOutputs;
+    public List<String> excludedOutputs = new ArrayList<>();
     
     
     @DisplayInfo(label="Automatic Purge Policy", desc="Policy for automatically purging stored data")


### PR DESCRIPTION
Initialize `excludeOutputs` to prevent #119 , null reference crash