### PR TITLE
Update Jetty version to fix memory leak while using WebSocket

### DIFF
--- a/sensorhub-core/build.gradle
+++ b/sensorhub-core/build.gradle
@@ -9,9 +9,9 @@ dependencies {
   compile 'com.google.code.gson:gson:2.7'
   compile 'ch.qos.logback:logback-classic:1.1.2'
   compile 'uk.com.robust-it:cloning:1.9.1'
-  compile 'org.eclipse.jetty:jetty-servlet:9.4.19.v20190610'
-  compile 'org.eclipse.jetty:jetty-servlets:9.4.19.v20190610'
-  compile 'org.eclipse.jetty:jetty-xml:9.4.19.v20190610'
+  compile 'org.eclipse.jetty:jetty-servlet:9.4.42.v20210604'
+  compile 'org.eclipse.jetty:jetty-servlets:9.4.42.v20210604'
+  compile 'org.eclipse.jetty:jetty-xml:9.4.42.v20210604'
     
   testCompile project(path: ':sensorml-core', configuration: 'testArtifacts')
   testCompile 'commons-io:commons-io:1.3.2'

--- a/sensorhub-service-swe/build.gradle
+++ b/sensorhub-service-swe/build.gradle
@@ -6,7 +6,7 @@ dependencies {
   compile project(':ogc-services-sos')
   compile project(':ogc-services-sps')
   compile 'xml-apis:xml-apis:1.4.01'
-  compile 'org.eclipse.jetty.websocket:websocket-server:9.4.19.v20190610'
+  compile 'org.eclipse.jetty.websocket:websocket-server:9.4.42.v20210604'
     
   testCompile project(path: ':sensorhub-core', configuration: 'testArtifacts')
   testCompile project(':sensorhub-storage-perst')


### PR DESCRIPTION
Memory leak happens while using WebSocket Service. Related to #172