### PR TITLE
Add simple reconnection logic to SOSClient

### DIFF
--- a/sensorhub-core/src/main/java/org/sensorhub/impl/module/RobustConnectionConfig.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/module/RobustConnectionConfig.java
@@ -28,14 +28,14 @@ import org.sensorhub.api.config.DisplayInfo;
 public class RobustConnectionConfig
 {
 
-    @DisplayInfo(label="Connection Timeout", desc="For each reconnection attempt, client will wait for the remote side to respond until this timeout expires (in ms)")
+    @DisplayInfo(label="Connection Timeout", desc="For each connection or reconnection attempt, the client will wait for the remote side to respond until this timeout expires (in ms)")
     public int connectTimeout = 3000;
     
     
-    @DisplayInfo(label="Reconnect Period", desc="Period at which client will attempt to reconnect when the connection is not available or lost (in ms)")
+    @DisplayInfo(label="Reconnect Period", desc="How long the client will wait after connection is lost before it will attempt to reconnect (in ms)")
     public int reconnectPeriod = 10000;
     
     
-    @DisplayInfo(label="Max Reconnect Attempts", desc="Maximum number of times the client will attempt to reconnect when the connection is not available or lost")
+    @DisplayInfo(label="Max Reconnect Attempts", desc="Maximum number of times the client will attempt to reconnect when the connection is not available or lost. A negative value means that there is no limit to the number of reconnection attempts. Zero means not to attempt reconnection.")
     public int reconnectAttempts = 0;
 }

--- a/sensorhub-service-swe/src/main/java/org/sensorhub/impl/client/sos/SOSClient.java
+++ b/sensorhub-service-swe/src/main/java/org/sensorhub/impl/client/sos/SOSClient.java
@@ -24,11 +24,11 @@ import java.net.PasswordAuthentication;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
-import net.opengis.sensorml.v20.AbstractProcess;
-import net.opengis.swe.v20.DataBlock;
-import net.opengis.swe.v20.DataComponent;
-import net.opengis.swe.v20.DataEncoding;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
 import org.eclipse.jetty.client.util.BasicAuthentication;
+import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.WebSocketAdapter;
 import org.eclipse.jetty.websocket.api.WebSocketListener;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
@@ -38,7 +38,6 @@ import org.slf4j.LoggerFactory;
 import org.vast.cdm.common.DataStreamParser;
 import org.vast.ogc.om.IObservation;
 import org.vast.ogc.om.OMUtils;
-import org.vast.ows.OWSException;
 import org.vast.ows.OWSExceptionReader;
 import org.vast.ows.sos.GetObservationRequest;
 import org.vast.ows.sos.GetResultRequest;
@@ -53,6 +52,11 @@ import org.vast.util.TimeExtent;
 import org.vast.xml.DOMHelper;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
+
+import net.opengis.sensorml.v20.AbstractProcess;
+import net.opengis.swe.v20.DataBlock;
+import net.opengis.swe.v20.DataComponent;
+import net.opengis.swe.v20.DataEncoding;
 
 
 /**
@@ -75,12 +79,66 @@ public class SOSClient
     DataComponent dataDescription;
     DataEncoding dataEncoding;
     boolean useWebsockets;
-    volatile boolean started;
     
+    /**
+     * Background threads that perform asynchronous work for this client. Right now this is only used when streaming
+     * observations to a caller.
+     */
+    ScheduledThreadPoolExecutor backgroundThreads;
     
-    public interface SOSRecordListener
-    {
-        public void newRecord(DataBlock data);
+    /**
+     * Counts the number of times that we have attempted to reconnect to the remote server for streaming observations.
+     * This is set to zero when streaming is started and incremented every time that the connection fails and we try to
+     * reconnect.
+     */
+    int streamingRetryAttempts;
+
+    /**
+     * The maximum number of times that we should attempt to reconnect to the remote server when streaming observations
+     * and the connection fails. If the value is negative, then there is no limit to the number of reconnect attempts.
+     * If the value is zero, do not attempt to reconnect at all.
+     */
+    int maxStreamingRetryAttempts = -1;
+    
+    /**
+     * Delay in milliseconds, after streaming observations have failed, before this class will attempt to reconnect to
+     * the remote server. Some delay is necessary to avoid rapid reconnection attempts that might overload network or
+     * CPU resources.
+     */
+    long delayBetweenStreamingRetryAttempts = 1000;
+    
+    /**
+     * True if we are streaming observations to a listener right now.
+     */
+    volatile boolean streamingStarted;
+    
+    /**
+     * Interface to be implemented by callers that want to receive streaming observation records.
+     */
+    public interface StreamingListener {
+        public void recordReceived(DataBlock data);
+        public void stopped(StreamingStopReason reason, Throwable cause);
+    }
+    
+    /**
+     * Enumeration of reasons why streaming has stopped.
+     */
+    public enum StreamingStopReason {
+    	/**
+    	 * Streaming was stopped at the callers request.
+    	 */
+    	REQUESTED,
+    	
+    	/**
+    	 * Streaming was stopped due to an unexpected Java exception performing the HTTP request, or during invocation
+    	 * of the caller-supplied handler.
+    	 */
+    	EXCEPTION,
+    	
+    	/**
+    	 * Streaming was stopped because we exceeded the maximum number of retry attempts.
+    	 */
+    	EXCEEDED_MAX_RETRIES
     }
 
 
@@ -88,15 +146,31 @@ public class SOSClient
     {
         this.grRequest = request;
         this.useWebsockets = useWebsockets;
+        backgroundThreads = createNewExecutor();
     }
     
-    
+    /**
+     * Retrieves a description of the sensor from the remote server. Requests the description in the default format
+     * (SensorML XML). The connection is performed synchronously.
+     *
+     * @param sensorUID
+     * @return
+     * @throws SensorHubException
+     */
     public AbstractProcess getSensorDescription(String sensorUID) throws SensorHubException
     {
         return getSensorDescription(sensorUID, DescribeSensorRequest.DEFAULT_FORMAT);
     }
     
-    
+    /**
+     * Retrieves a description of the sensor from the remote server, requesting the description in the provided format.
+     * The connection is performed synchronously.
+     * 
+     * @param sensorUID
+     * @param format
+     * @return
+     * @throws SensorHubException
+     */
     public AbstractProcess getSensorDescription(String sensorUID, String format) throws SensorHubException
     {
         Asserts.checkNotNull(sensorUID, "sensorUID");
@@ -142,7 +216,16 @@ public class SOSClient
         }
     }
     
-    
+    /**
+     * Calls the "GetResultTemplate" request on the remote server and uses the return value to initialize member
+     * variables that will later be used for decoding streamed observations.
+     * 
+     * This must be called before {@link #startStream(StreamingListener)}.
+     * 
+     * Runs synchronously and blocks until the request completes.
+     *
+     * @throws SensorHubException
+     */
     public void retrieveStreamDescription() throws SensorHubException
     {
         // create output definition
@@ -201,166 +284,236 @@ public class SOSClient
         }
     }
 
+	/**
+	 * Starts streaming observations from the server and emitting events to the listener for each record that is
+	 * received. Has no effect if we're already currently streaming. All callbacks occur in a background thread.
+	 *
+	 * @param listener Object whose methods will be called when records are received or the streaming has stopped.
+	 */
+    public synchronized void startStream(final StreamingListener listener) {
+    	if (dataEncoding == null) {
+    		throw new IllegalStateException("dataEncoding is null. retrieveStreamDescription must be called before starting streaming.");
+    	}
+    	if (dataDescription == null) {
+    		throw new IllegalStateException("dataDescription is null. retrieveStreamDescription must be called before starting streaming.");
+    	}
+    	if (listener == null) {
+    		throw new IllegalArgumentException("The listener provided to startStream(...) cannot be null");
+    	}
 
-    public void startStream(SOSRecordListener listener) throws SensorHubException
-    {
-        if (started)
+    	if (streamingStarted) {
+        	log.debug("startStream(...) called, but we're already started. Ignoring.");
             return;
+        } else {
+        	log.debug("startStream(...) called. useWebsockets: {}", useWebsockets);
+        }
         
-        // prepare parser
+        // Prepare a parser to extract the data out of whatever we receive from the server.
         DataStreamParser parser = SWEHelper.createDataParser(dataEncoding);
         parser.setDataComponents(dataDescription);
         parser.setRenewDataBlock(true);
 
-        if (useWebsockets)
-            connectWithWebsockets(parser, listener);
-        else
+        streamingRetryAttempts = 0;
+    	streamingStarted = true;
+        if (useWebsockets) {
+            connectWithWebSockets(parser, listener);
+        } else {
             connectWithPersistentHttp(parser, listener);
+        }
+    }
+    
+    /**
+     * Close the parser and eat any exceptions after logging them.
+     */
+    protected void closeParser(final DataStreamParser parser) {
+		try {
+			if (parser != null) {
+				parser.close();
+			}
+		} catch (Exception e) {
+			log.error("Unable to close SWE parser", e);
+		}
     }
 
-
-    protected void connectWithPersistentHttp(final DataStreamParser parser, final SOSRecordListener listener) throws SensorHubException
-    {
-        // connect to data stream
-        try
-        {
-            log.debug("Connecting to {}", sosUtils.buildURLQuery(grRequest));
-            grRequest.setConnectTimeOut(60000);
-            HttpURLConnection conn = sosUtils.sendGetRequest(grRequest);
-            InputStream is = new BufferedInputStream(conn.getInputStream());
-            parser.setInput(is);
-        }
-        catch (Exception e)
-        {
-            throw new SensorHubException("Error while connecting to SOS data stream", e);
-        }
-
-        // start parsing data
-        Thread parseThread = new Thread()
-        {
-            public void run()
-            {
-                started = true;
-                DataBlock data;
-
-                try
-                {
-                    while (started && (data = parser.parseNextBlock()) != null)
-                        listener.newRecord(data);
-                }
-                catch (IOException e)
-                {
-                    if (started)
-                        log.error("Error while parsing SOS data stream", e);
-                }
-                finally
-                {
-                    try
-                    {
-                        parser.close();
-                    }
-                    catch (IOException e)
-                    {
-                        log.trace("Cannot close SOS connection", e);
-                    }
-                    
-                    started = false;
-                }
-            }
-        };
-
-        parseThread.start();
+    /**
+     * Run a background thread that does the (blocking) HTTP GetRecord request.
+     */
+    protected void connectWithPersistentHttp(final DataStreamParser parser, final StreamingListener listener) {
+    	backgroundThreads.execute(() -> connectWithPersistentHttpAndCleanUp(parser, listener));
+    }
+    
+    /**
+     * Entry point for the background thread that keeps connecting via long polling HTTP GET requests.
+     * This just delegates to the worker method below and ensures that the parser gets cleaned up.
+     */
+    protected void connectWithPersistentHttpAndCleanUp(final DataStreamParser parser, final StreamingListener listener) {
+    	try {
+    		persistenHttpRetryLoop(parser, listener);
+    	} finally {
+    		closeParser(parser);
+    	}
     }
 
+    /**
+     * Loops forever, attempting to do HTTP GET GetRecord requests until streaming is stopped, a fatal error happens,
+     * or the max retry attempts are exceeded.
+     */
+    protected void persistenHttpRetryLoop(final DataStreamParser parser, final StreamingListener listener) {
+    	Exception lastException = null;
 
-    protected void connectWithWebsockets(final DataStreamParser parser, final SOSRecordListener listener) throws SensorHubException
-    {
+    	while (streamingStarted) {
+    		// First try to open up the HTTP connection for the GetRecord request.
+    		boolean connectionSucceeded = false;
+    		try {
+	            log.debug("Initiating GetRecord request");
+	            grRequest.setConnectTimeOut(60000);
+	            HttpURLConnection conn = sosUtils.sendGetRequest(grRequest);
+	            InputStream is = new BufferedInputStream(conn.getInputStream());
+	            parser.setInput(is);
+	            connectionSucceeded = true;
+    		} catch (Exception e) {
+    			lastException = e;
+    			log.error("Uncaught exception attempting to establish a connection for GetRecord request", e);
+    		}
+
+    		if (Thread.interrupted()) {
+    			// If the thread has been interrupted, then we should just quit immediately because it means that
+    			// the thread pool has been destroyed, which should only happen when stopStream is called.
+    			log.debug("Thread was interrupted while attempting initial GetRecord. Assuming we've been stopped.");
+    			return;
+    		}
+    		
+    		// If the initial connection succeeded, read from it forever until it breaks or until it returns null.
+        	if (connectionSucceeded) {
+	            try {
+	                while (streamingStarted) {
+	                	if (Thread.interrupted()) {
+	            			// Again, if the thread was interrupted, assume that the client was stopped and quit now.
+	            			log.debug("Thread was interrupted while reading. Assuming we've been stopped.");
+	            			return;
+	            		}
+
+	                	DataBlock data = parser.parseNextBlock();
+	                	if (data == null) {
+	                		log.debug("Null data block returned. Breaking out of loop to reconnect.");
+	                		break;
+	                	} else {
+	                		log.debug("Received data block from server.");
+	                		listener.recordReceived(data);
+	                	}
+	                }
+	            } catch (Exception e) {
+	            	lastException = e;
+	            	log.error("Error while parsing SOS data stream", e);
+	            }
+        	}
+
+        	// One last check for interrupted-ness to make sure we don't need to quit now.
+        	if (Thread.interrupted()) {
+    			log.debug("Thread was interrupted. Assuming we've been stopped.");
+    			return;
+    		}
+
+        	// If we reach the end of this loop and we're still started, then we may need to restart.
+    		if (streamingStarted) {
+    			if ((maxStreamingRetryAttempts < 0) || (streamingRetryAttempts < maxStreamingRetryAttempts)) {
+    				streamingRetryAttempts++;
+					log.debug("Delaying {} milliseconds before reconnect number {}", delayBetweenStreamingRetryAttempts, streamingRetryAttempts);
+    				try {
+    					Thread.sleep(delayBetweenStreamingRetryAttempts);
+    				} catch (InterruptedException ie) {
+    					log.info("Interrupted while waiting to retry. Quitting.");
+    					listener.stopped(StreamingStopReason.REQUESTED, null);
+    					break;
+    				}
+    			} else {
+    				log.debug("Maximum retry attempts reached. Quitting.");
+    				streamingStarted = false;
+    				listener.stopped(StreamingStopReason.EXCEEDED_MAX_RETRIES, lastException);
+    				break;
+    			}
+    		} else {
+    			listener.stopped(StreamingStopReason.REQUESTED, null);
+    		}
+    	} // end of "while (streamingStarted)"
+    }
+
+    protected void connectWithWebSockets(final DataStreamParser parser, final StreamingListener listener) {
         String destUri = null;
-        try
-        {
+        try {
             destUri = sosUtils.buildURLQuery(grRequest);
             destUri = destUri.replace("http://", "ws://")
                              .replace("https://", "wss://");
-        }
-        catch (OWSException e)
-        {
-            throw new SensorHubException("Error while generating websocket SOS request", e);
-        }
-
-        WebSocketListener socket = new WebSocketAdapter() {            
-            
-            @Override
-            public void onWebSocketBinary(byte[] payload, int offset, int len)
-            {
-                try
-                {
-                    // skip if no payload
-                    if (payload == null || payload.length == 0)
-                        return;
-                    
-                    ByteArrayInputStream is = new ByteArrayInputStream(payload, offset, len);
-                    parser.setInput(is);
-                    DataBlock data = parser.parseNextBlock();
-                    listener.newRecord(data);
-                }
-                catch (IOException e)
-                {
-                    log.error("Error while parsing websocket packet", e);
-                }
-            }
-
-            @Override
-            public void onWebSocketClose(int statusCode, String reason)
-            {
-                
-            }
-
-            @Override
-            public void onWebSocketError(Throwable cause)
-            {
-                log.error("Error connecting to websocket", cause);
-            }            
-        };
-        
-        try
-        {
-            // init WS client with optional auth
-            wsClient = new WebSocketClient();
-            PasswordAuthentication auth = Authenticator.requestPasswordAuthentication(grRequest.getGetServer(), null, 0, null, null, null);
-            if (auth != null) {
-                wsClient.getHttpClient().getAuthenticationStore().addAuthenticationResult(
-                        new BasicAuthentication.BasicResult(new URI(destUri), auth.getUserName(), new String(auth.getPassword())));
-            }
-            started = true;
-            wsClient.start();
-            URI wsUri = new URI(destUri);
-            wsClient.connect(socket, wsUri);
-            log.debug("Connecting to {}", destUri);
-        }
-        catch (Exception e)
-        {
-            throw new SensorHubException("Error while connecting to SOS data stream", e);
+            SOSClientWebSocketListener webSocketListener = new SOSClientWebSocketListener(parser, listener);
+            connectWithWebSockets(destUri, webSocketListener);
+        } catch (Exception e) {
+        	listener.stopped(StreamingStopReason.EXCEPTION, e);
+        	closeParser(parser);
+        	streamingStarted = false;
         }
     }
+    
+    private void connectWithWebSockets(String wsUriString, WebSocketListener webSocketListener) throws Exception {
+        // init WS client with optional auth
+        wsClient = new WebSocketClient();
+        PasswordAuthentication auth = Authenticator.requestPasswordAuthentication(grRequest.getGetServer(), null, 0, null, null, null);
+        if (auth != null) {
+            wsClient.getHttpClient().getAuthenticationStore().addAuthenticationResult(
+                    new BasicAuthentication.BasicResult(new URI(wsUriString), auth.getUserName(), new String(auth.getPassword())));
+        }
 
+        wsClient.start();
+        URI wsUri = new URI(wsUriString);
+        log.debug("Asynchronously connecting to {}", wsUriString);
+        wsClient.connect(webSocketListener, wsUri);
+    }
 
-    public void stopStream()
+    private void scheduleWebSocketReconnect(final DataStreamParser parser, final StreamingListener listener) {
+    	if (streamingStarted) {
+	    	if ((maxStreamingRetryAttempts < 0) || (streamingRetryAttempts < maxStreamingRetryAttempts)) {
+	    		log.debug("Scheduling websocket reconnect in {} ms", delayBetweenStreamingRetryAttempts);
+				streamingRetryAttempts++;
+				backgroundThreads.schedule(() -> connectWithWebSockets(parser, listener), delayBetweenStreamingRetryAttempts, TimeUnit.MILLISECONDS);
+	    	} else {
+	    		log.debug("Retry limit reached. Not scheduling websocket reconnect.");
+	    		listener.stopped(StreamingStopReason.EXCEEDED_MAX_RETRIES, null);
+	    		closeParser(parser);
+	    	}
+    	} else {
+    		log.debug("Streaming is stopped. Not scheduling a reconnect.");
+    	}
+    }
+
+    public synchronized void stopStream()
     {
-        started = false;
-        
-        if (wsClient != null)
-        {
-            try
-            {
-                wsClient.stop();
-            }
-            catch (Exception e)
-            {
-                log.trace("Cannot close websocket client", e);
-            }
-        }
+    	if (streamingStarted) {
+	        streamingStarted = false;
+	        
+	        if (wsClient != null)
+	        {
+	            try
+	            {
+	                wsClient.stop();
+	            }
+	            catch (Exception e)
+	            {
+	                log.trace("Cannot close websocket client", e);
+	            }
+	        }
+	        // Kill off any existing threads as best we can.
+	        // PENDING(CSD): The long polling HTTP client is not interrupted by this call.
+	        // So when the request eventually times out after 60 seconds, the thread will
+	        // either 
+	        backgroundThreads.shutdownNow();
+	        backgroundThreads = createNewExecutor();
+    	}
     }
 
+    protected ScheduledThreadPoolExecutor createNewExecutor() {
+        // HTTP long polling needs 2 threads: one to do the work and another for scheduling restarts.
+    	// The Jetty WebSocket client uses its own thread pool.
+        return new ScheduledThreadPoolExecutor(2);
+    }
 
     public DataComponent getRecordDescription()
     {
@@ -371,5 +524,60 @@ public class SOSClient
     public DataEncoding getRecommendedEncoding()
     {
         return dataEncoding;
+    }
+    
+    private class SOSClientWebSocketListener extends WebSocketAdapter {
+    	private final DataStreamParser parser;
+    	private final StreamingListener listener;
+
+    	public SOSClientWebSocketListener(final DataStreamParser parser, final StreamingListener listener) {
+        	this.parser = parser;
+        	this.listener = listener;
+        }
+
+        @Override
+		public void onWebSocketConnect(Session sess) {
+			super.onWebSocketConnect(sess);
+			log.debug("WebSocket connected.");
+		}
+
+		@Override
+        public void onWebSocketBinary(byte[] payload, int offset, int len) {
+            try {
+                // Skip if no payload
+                if ((payload == null) || (payload.length == 0) || (len == 0)) {
+                	log.debug("Received empty websocket payload. Skipping.");
+                    return;
+                } else {
+                	log.debug("Received websocket payload of {} bytes", payload.length);
+                }
+                
+                ByteArrayInputStream is = new ByteArrayInputStream(payload, offset, len);
+                parser.setInput(is);
+                DataBlock data = parser.parseNextBlock();
+                listener.recordReceived(data);
+            } catch (IOException e) {
+                log.error("Error while parsing websocket packet", e);
+                if (streamingStarted) {
+                	scheduleWebSocketReconnect(parser, listener);
+                }
+            }
+        }
+
+        @Override
+        public void onWebSocketClose(int statusCode, String reason) {
+        	log.debug("WebSocket closed. Status: {}. Reason: {}", statusCode, reason);
+            if (streamingStarted) {
+            	scheduleWebSocketReconnect(parser, listener);
+            }
+        }
+
+        @Override
+        public void onWebSocketError(Throwable cause) {
+            log.error("Error connecting to websocket", cause);
+            if (streamingStarted) {
+            	scheduleWebSocketReconnect(parser, listener);
+            }
+        }            
     }
 }

--- a/sensorhub-service-swe/src/main/java/org/sensorhub/impl/sensor/swe/SWEVirtualSensor.java
+++ b/sensorhub-service-swe/src/main/java/org/sensorhub/impl/sensor/swe/SWEVirtualSensor.java
@@ -165,7 +165,10 @@ public class SWEVirtualSensor extends AbstractSensorModule<SWEVirtualSensorConfi
                                 req.setXmlWrapper(false);
                                 
                                 // create client and retrieve result template
-                                SOSClient sos = new SOSClient(req, config.sosUseWebsockets);                                
+                                SOSClient sos = new SOSClient(req, config.sosUseWebsockets,
+                                		config.connectionConfig.connectTimeout,
+                                		config.connectionConfig.reconnectAttempts,
+                                		config.connectionConfig.reconnectPeriod);
                                 
                                 DataComponent recordDef;
                                 try

--- a/sensorhub-service-swe/src/main/java/org/sensorhub/impl/sensor/swe/SWEVirtualSensorConfig.java
+++ b/sensorhub-service-swe/src/main/java/org/sensorhub/impl/sensor/swe/SWEVirtualSensorConfig.java
@@ -19,6 +19,7 @@ import java.util.List;
 import org.sensorhub.api.config.DisplayInfo;
 import org.sensorhub.api.sensor.SensorConfig;
 import org.sensorhub.impl.comm.HTTPConfig;
+import org.sensorhub.impl.module.RobustConnectionConfig;
 
 
 /**
@@ -48,11 +49,22 @@ public class SWEVirtualSensorConfig extends SensorConfig
     
     //@DisplayInfo(label="Use WebSockets for SPS", desc="Set if websockets protocol should be used to send commands to SPS")
     //public boolean spsUseWebsockets = false;
-           
+    
+    @DisplayInfo(label="Connection Settings")
+    public RobustConnectionConfig connectionConfig = new RobustConnectionConfig();
     
     public SWEVirtualSensorConfig()
     {
         this.moduleClass = SWEVirtualSensor.class.getCanonicalName();
+        // Set a longer connection timeout than the default offered by RobustConnectionConfig.
+        // This will allow us to wait longer for observations, in cases where observations are
+        // infrequent.
+        connectionConfig.connectTimeout = 30000;
+        // Set a shorter time between reconnection attempts, so that data is less likely to be
+        // lost during the outage.
+        connectionConfig.reconnectPeriod = 1000;
+        // Set the default to allow infinitely many reconnection attempts.
+        connectionConfig.reconnectAttempts = -1;
     }
 
 }

--- a/sensorhub-service-swe/src/test/java/org/sensorhub/impl/service/sos/TestSOSClient.java
+++ b/sensorhub-service-swe/src/test/java/org/sensorhub/impl/service/sos/TestSOSClient.java
@@ -22,12 +22,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.sensorhub.impl.client.sos.SOSClient;
-import org.sensorhub.impl.client.sos.SOSClient.SOSRecordListener;
+import org.sensorhub.impl.client.sos.SOSClient.StreamingListener;
+import org.sensorhub.impl.client.sos.SOSClient.StreamingStopReason;
 import org.vast.ows.sos.GetResultRequest;
 import org.vast.util.TimeExtent;
 
 
-public class TestSOSClient implements SOSRecordListener
+public class TestSOSClient implements StreamingListener
 {
     TestSOSService sosTest;
     int recordCounter = 0;
@@ -90,11 +91,16 @@ public class TestSOSClient implements SOSRecordListener
     
     
     @Override
-    public void newRecord(DataBlock data)
+    public void recordReceived(DataBlock data)
     {
         System.out.println("Record received: " + data);
         recordCounter++;
-    }    
+    }
+    
+    @Override
+    public void stopped(StreamingStopReason reason, Throwable cause) {
+    	System.out.println("SOS Client stopped");
+    }
     
    
     @After

--- a/sensorhub-service-swe/src/test/java/org/sensorhub/impl/service/sos/TestSOSClient.java
+++ b/sensorhub-service-swe/src/test/java/org/sensorhub/impl/service/sos/TestSOSClient.java
@@ -32,6 +32,7 @@ public class TestSOSClient implements StreamingListener
 {
     TestSOSService sosTest;
     int recordCounter = 0;
+    int stopCounter = 0;
     
     
     @Before
@@ -53,7 +54,7 @@ public class TestSOSClient implements StreamingListener
         req.setTime(TimeExtent.beginNow(Instant.now().plus(1, ChronoUnit.MINUTES)));
         req.setXmlWrapper(false);
         
-        SOSClient client = new SOSClient(req, false);
+        SOSClient client = new SOSClient(req, false, 1000, 0, 600_000L);
         
         // start service and client
         sosTest.testSetupService();
@@ -77,7 +78,7 @@ public class TestSOSClient implements StreamingListener
         req.setTime(TimeExtent.beginNow(Instant.now().plus(1, ChronoUnit.MINUTES)));
         req.setXmlWrapper(false);
         
-        SOSClient client = new SOSClient(req, true);
+        SOSClient client = new SOSClient(req, true, 1000, 0, 600_000L);
         
         // start service and client
         sosTest.testSetupService();
@@ -89,7 +90,69 @@ public class TestSOSClient implements StreamingListener
         assertTrue(recordCounter > 0);
     }
     
-    
+    /**
+     * Test to make sure that the SOSClient attempts to reconnect.
+     */
+    @Test
+    public void testWebsocketReconnect() throws Exception {
+        GetResultRequest req = new GetResultRequest();
+        req.setGetServer(TestSOSService.HTTP_ENDPOINT);
+        req.setVersion("2.0");
+        req.setOffering(TestSOSService.URI_OFFERING1);
+        req.getObservables().add(TestSOSService.URI_PROP1);
+        req.setTime(TimeExtent.beginNow(Instant.now().plus(1, ChronoUnit.MINUTES)));
+        req.setXmlWrapper(false);
+        
+        SOSClient client = new SOSClient(req, true, 1000, 1, 600_000);
+        
+        // start service and client
+        sosTest.testSetupService();
+        client.retrieveStreamDescription();
+        client.startStream(this);
+
+        // wait until some records have been received
+        Thread.sleep(1000L);
+        
+        // Shut down the server
+        sosTest.hub.stop();
+        Thread.sleep(1000L);
+
+        assertTrue(client.getStreamingRetryAttempts() > 0);
+        client.stopStream();
+    }
+        
+    /**
+     * Test that SOSClient honors the max retry limit and calls stopped(...)
+     */
+    @Test
+    public void testNoReconnect() throws Exception {
+        GetResultRequest req = new GetResultRequest();
+        req.setGetServer(TestSOSService.HTTP_ENDPOINT);
+        req.setVersion("2.0");
+        req.setOffering(TestSOSService.URI_OFFERING1);
+        req.getObservables().add(TestSOSService.URI_PROP1);
+        req.setTime(TimeExtent.beginNow(Instant.now().plus(1, ChronoUnit.MINUTES)));
+        req.setXmlWrapper(false);
+        
+        SOSClient client = new SOSClient(req, true, 1000, 0, 1000);
+        
+        // start service and client
+        sosTest.testSetupService();
+        client.retrieveStreamDescription();
+        client.startStream(this);
+
+        // wait until some records have been received
+        Thread.sleep(1000L);
+        
+        // Shut down the server, causing the websocket closure
+        sosTest.hub.stop();
+        Thread.sleep(1000L);
+
+        // Make sure our listener was called
+        assertTrue(stopCounter > 0);
+        client.stopStream();
+    }
+
     @Override
     public void recordReceived(DataBlock data)
     {
@@ -100,6 +163,7 @@ public class TestSOSClient implements StreamingListener
     @Override
     public void stopped(StreamingStopReason reason, Throwable cause) {
     	System.out.println("SOS Client stopped");
+    	stopCounter++;
     }
     
    


### PR DESCRIPTION
The commits in this pull request add simple reconnection logic to the SOSClient so that observations are less likely to be lost when there are network issues or periods of inactivity that cause closed connections. (This improves the functionality of the SWEVirtualSensor, which uses the SOSClient under the hood.)

Note that these changes are still not a perfect solution for every use case. Observations that occur during an outage will not be transferred when the reconnection succeeds.

The connections (either websocket or plain http) managed by SOSClient are performed in a background thread. This has the side-effect of making the SWEVirtualSensor always start immediately (rather than having to wait for an initial response). Almost all exceptions or errors that occur are logged, and then a reconnection is scheduled. Only 401/403 errors will cause a failure that results in the sensor being stopped.