### PR TITLE
Implement TCPServerCommProvider

### DIFF
--- a/sensorhub-core/src/main/java/org/sensorhub/api/comm/ICommProvider.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/api/comm/ICommProvider.java
@@ -8,7 +8,7 @@
  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
  for the specific language governing rights and limitations under the License.
 
- Copyright (C) 2012-2015 Sensia Software LLC. All Rights Reserved.
+ Copyright (C) 2012-2023 Sensia Software LLC. and Botts Innovative Research, Inc. All Rights Reserved.
  ******************************* END LICENSE BLOCK ***************************/
 
 package org.sensorhub.api.comm;

--- a/sensorhub-core/src/main/java/org/sensorhub/api/comm/ICommProvider.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/api/comm/ICommProvider.java
@@ -1,24 +1,25 @@
 /***************************** BEGIN LICENSE BLOCK ***************************
 
-The contents of this file are subject to the Mozilla Public License, v. 2.0.
-If a copy of the MPL was not distributed with this file, You can obtain one
-at http://mozilla.org/MPL/2.0/.
+ The contents of this file are subject to the Mozilla Public License, v. 2.0.
+ If a copy of the MPL was not distributed with this file, You can obtain one
+ at http://mozilla.org/MPL/2.0/.
 
-Software distributed under the License is distributed on an "AS IS" basis,
-WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
-for the specific language governing rights and limitations under the License.
- 
-Copyright (C) 2012-2015 Sensia Software LLC. All Rights Reserved.
- 
-******************************* END LICENSE BLOCK ***************************/
+ Software distributed under the License is distributed on an "AS IS" basis,
+ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ for the specific language governing rights and limitations under the License.
+
+ Copyright (C) 2012-2015 Sensia Software LLC. All Rights Reserved.
+ ******************************* END LICENSE BLOCK ***************************/
 
 package org.sensorhub.api.comm;
+
+import org.sensorhub.api.module.IModule;
+import org.sensorhub.impl.comm.ConnectionEventArgs;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import org.sensorhub.api.module.IModule;
-
+import java.util.function.Consumer;
 
 /**
  * <p>
@@ -26,16 +27,27 @@ import org.sensorhub.api.module.IModule;
  * for reading incoming data and an output stream for sending outgoing data.
  * </p>
  *
- * @author Alex Robin
  * @param <ConfigType> Comm module config type
+ * @author Alex Robin
  * @since Jun 19, 2015
  */
-public interface ICommProvider<ConfigType extends CommProviderConfig<?>> extends IModule<ConfigType>
-{
-    
-    public InputStream getInputStream() throws IOException;
-    
-    
-    public OutputStream getOutputStream() throws IOException;
-    
+public interface ICommProvider<ConfigType extends CommProviderConfig<?>> extends IModule<ConfigType> {
+
+    InputStream getInputStream() throws IOException;
+
+
+    OutputStream getOutputStream() throws IOException;
+
+    /**
+     * Adds a connection event handler to this comm provider.
+     * The handler will be called when a connection is established.
+     * <p>
+     * For client comm providers, this will be called when the comm module starts.
+     * Make sure to register the handler before starting the module or the event will be missed.
+     * <p>
+     * For server comm providers, this will be called every time a client connects.
+     *
+     * @param eventHandler The event handler to add
+     */
+    void onConnection(Consumer<ConnectionEventArgs> eventHandler);
 }

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/comm/ConnectionEventArgs.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/comm/ConnectionEventArgs.java
@@ -1,0 +1,50 @@
+/***************************** BEGIN LICENSE BLOCK ***************************
+ The contents of this file are subject to the Mozilla Public License, v. 2.0.
+ If a copy of the MPL was not distributed with this file, You can obtain one
+ at http://mozilla.org/MPL/2.0/.
+
+ Software distributed under the License is distributed on an "AS IS" basis,
+ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ for the specific language governing rights and limitations under the License.
+
+ Copyright (C) 2023 Botts Innovative Research Inc. All Rights Reserved.
+ ******************************* END LICENSE BLOCK ***************************/
+
+package org.sensorhub.impl.comm;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Event arguments for a connection event
+ *
+ * @author Michael Elmore
+ * @since September 2023
+ */
+public class ConnectionEventArgs {
+    private final InputStream inputStream;
+    private final OutputStream outputStream;
+
+    /**
+     * @param inputStream  The input stream for the connection
+     * @param outputStream The output stream for the connection
+     */
+    public ConnectionEventArgs(InputStream inputStream, OutputStream outputStream) {
+        this.inputStream = inputStream;
+        this.outputStream = outputStream;
+    }
+
+    /**
+     * @return The input stream for the connection
+     */
+    public InputStream getInputStream() {
+        return inputStream;
+    }
+
+    /**
+     * @return The output stream for the connection
+     */
+    public OutputStream getOutputStream() {
+        return outputStream;
+    }
+}

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/comm/TCPCommProvider.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/comm/TCPCommProvider.java
@@ -8,7 +8,7 @@
  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
  for the specific language governing rights and limitations under the License.
 
- Copyright (C) 2012-2015 Sensia Software LLC. All Rights Reserved.
+ Copyright (C) 2012-2023 Sensia Software LLC. and Botts Innovative Research, Inc. All Rights Reserved.
  ******************************* END LICENSE BLOCK ***************************/
 
 package org.sensorhub.impl.comm;

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/comm/TCPCommProvider.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/comm/TCPCommProvider.java
@@ -1,19 +1,26 @@
 /***************************** BEGIN LICENSE BLOCK ***************************
 
-The contents of this file are subject to the Mozilla Public License, v. 2.0.
-If a copy of the MPL was not distributed with this file, You can obtain one
-at http://mozilla.org/MPL/2.0/.
+ The contents of this file are subject to the Mozilla Public License, v. 2.0.
+ If a copy of the MPL was not distributed with this file, You can obtain one
+ at http://mozilla.org/MPL/2.0/.
 
-Software distributed under the License is distributed on an "AS IS" basis,
-WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
-for the specific language governing rights and limitations under the License.
- 
-Copyright (C) 2012-2015 Sensia Software LLC. All Rights Reserved.
- 
-******************************* END LICENSE BLOCK ***************************/
+ Software distributed under the License is distributed on an "AS IS" basis,
+ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ for the specific language governing rights and limitations under the License.
+
+ Copyright (C) 2012-2015 Sensia Software LLC. All Rights Reserved.
+ ******************************* END LICENSE BLOCK ***************************/
 
 package org.sensorhub.impl.comm;
 
+import org.sensorhub.api.comm.ICommProvider;
+import org.sensorhub.api.common.SensorHubException;
+import org.sensorhub.impl.module.AbstractModule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -21,13 +28,9 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
-import javax.net.ssl.SSLSocket;
-import javax.net.ssl.SSLSocketFactory;
-import org.sensorhub.api.comm.ICommProvider;
-import org.sensorhub.api.common.SensorHubException;
-import org.sensorhub.impl.module.AbstractModule;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Consumer;
 
 
 /**
@@ -38,84 +41,79 @@ import org.slf4j.LoggerFactory;
  * @author Alex Robin
  * @since July 2, 2015
  */
-public class TCPCommProvider extends AbstractModule<TCPCommProviderConfig> implements ICommProvider<TCPCommProviderConfig>
-{
+public class TCPCommProvider extends AbstractModule<TCPCommProviderConfig> implements ICommProvider<TCPCommProviderConfig> {
     static final Logger log = LoggerFactory.getLogger(TCPCommProvider.class.getSimpleName());
-    
+    private final Set<Consumer<ConnectionEventArgs>> listeners = new HashSet<>();
+
     Socket socket;
     InputStream is;
     OutputStream os;
-    
-    
-    public TCPCommProvider() 
-    {
+
+
+    public TCPCommProvider() {
     }
-    
-    
+
+
     @Override
-    public InputStream getInputStream() throws IOException
-    {
+    public InputStream getInputStream() throws IOException {
         return is;
     }
 
 
     @Override
-    public OutputStream getOutputStream() throws IOException
-    {
+    public OutputStream getOutputStream() throws IOException {
         return os;
     }
 
 
     @Override
-    protected void doStart() throws SensorHubException
-    {        
+    protected void doStart() throws SensorHubException {
         TCPConfig config = this.config.protocol;
-        
-        try
-        {
+
+        try {
             InetAddress addr = InetAddress.getByName(config.remoteHost);
-            
-            if (config.enableTLS)
-            {
-                SSLSocketFactory factory = (SSLSocketFactory)SSLSocketFactory.getDefault();
+
+            if (config.enableTLS) {
+                SSLSocketFactory factory = (SSLSocketFactory) SSLSocketFactory.getDefault();
                 socket = factory.createSocket(addr, config.remotePort);
-                ((SSLSocket)socket).startHandshake();
-                is = socket.getInputStream();
-                os = socket.getOutputStream();
-            }
-            else
-            {
+                ((SSLSocket) socket).startHandshake();
+            } else {
                 SocketAddress endpoint = new InetSocketAddress(addr, config.remotePort);
                 socket = new Socket();
                 socket.connect(endpoint, 1000);
-                is = socket.getInputStream();
-                os = socket.getOutputStream();
             }
-        }
-        catch (IOException e)
-        {
+
+            is = socket.getInputStream();
+            os = socket.getOutputStream();
+            broadcast(is, os);
+        } catch (IOException e) {
             throw new SensorHubException("Cannot connect to remote host "
-                                         + config.remoteHost + ":" + config.remotePort + " via TCP", e);
+                    + config.remoteHost + ":" + config.remotePort + " via TCP", e);
         }
     }
 
 
     @Override
-    protected void doStop() throws SensorHubException
-    {
-        try
-        {
+    protected void doStop() throws SensorHubException {
+        try {
             socket.close();
-        }
-        catch (IOException e)
-        {
+        } catch (IOException e) {
             log.trace("Cannot close socket", e);
-        }        
+        }
     }
 
 
     @Override
-    public void cleanup() throws SensorHubException
-    {
+    public void cleanup() throws SensorHubException {
+    }
+
+    @Override
+    public void onConnection(Consumer<ConnectionEventArgs> eventHandler) {
+        listeners.add(eventHandler);
+    }
+
+    private void broadcast(InputStream input, OutputStream output) {
+        var args = new ConnectionEventArgs(input, output);
+        listeners.forEach(listener -> listener.accept(args));
     }
 }

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/comm/TCPServerCommModuleDescriptor.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/comm/TCPServerCommModuleDescriptor.java
@@ -1,0 +1,46 @@
+/***************************** BEGIN LICENSE BLOCK ***************************
+ The contents of this file are subject to the Mozilla Public License, v. 2.0.
+ If a copy of the MPL was not distributed with this file, You can obtain one
+ at http://mozilla.org/MPL/2.0/.
+
+ Software distributed under the License is distributed on an "AS IS" basis,
+ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ for the specific language governing rights and limitations under the License.
+
+ Copyright (C) 2023 Botts Innovative Research Inc. All Rights Reserved.
+ ******************************* END LICENSE BLOCK ***************************/
+
+package org.sensorhub.impl.comm;
+
+import org.sensorhub.api.module.IModule;
+import org.sensorhub.api.module.IModuleProvider;
+import org.sensorhub.api.module.ModuleConfig;
+import org.sensorhub.impl.module.JarModuleProvider;
+
+/**
+ * Communication provider for TCP/IP server connections.
+ *
+ * @author Michael Elmore
+ * @since September 2023
+ */
+public class TCPServerCommModuleDescriptor extends JarModuleProvider implements IModuleProvider {
+    @Override
+    public String getModuleName() {
+        return "TCP Server Comm Driver";
+    }
+
+    @Override
+    public String getModuleDescription() {
+        return "Simple TCP/IP server communication provider using JDK TCP stack";
+    }
+
+    @Override
+    public Class<? extends IModule<?>> getModuleClass() {
+        return TCPServerCommProvider.class;
+    }
+
+    @Override
+    public Class<? extends ModuleConfig> getModuleConfigClass() {
+        return TCPServerCommProviderConfig.class;
+    }
+}

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/comm/TCPServerCommProvider.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/comm/TCPServerCommProvider.java
@@ -83,7 +83,7 @@ public class TCPServerCommProvider extends AbstractModule<TCPServerCommProviderC
                 serverThread.interrupt();
             }
         } catch (IOException e) {
-            log.error("TCPServerCommProvider error: " + e.getMessage());
+            throw new SensorHubException("Error stopping TCPServerCommProvider: " + e.getMessage(), e);
         }
     }
 

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/comm/TCPServerCommProvider.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/comm/TCPServerCommProvider.java
@@ -1,0 +1,136 @@
+/***************************** BEGIN LICENSE BLOCK ***************************
+ The contents of this file are subject to the Mozilla Public License, v. 2.0.
+ If a copy of the MPL was not distributed with this file, You can obtain one
+ at http://mozilla.org/MPL/2.0/.
+
+ Software distributed under the License is distributed on an "AS IS" basis,
+ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ for the specific language governing rights and limitations under the License.
+
+ Copyright (C) 2023 Botts Innovative Research Inc. All Rights Reserved.
+ ******************************* END LICENSE BLOCK ***************************/
+
+package org.sensorhub.impl.comm;
+
+import org.sensorhub.api.comm.ICommProvider;
+import org.sensorhub.api.common.SensorHubException;
+import org.sensorhub.impl.module.AbstractModule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLServerSocketFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Consumer;
+
+/**
+ * Communication provider for TCP/IP server connections.
+ *
+ * @author Michael Elmore
+ * @since September 2023
+ */
+public class TCPServerCommProvider extends AbstractModule<TCPServerCommProviderConfig> implements ICommProvider<TCPServerCommProviderConfig> {
+    static final Logger log = LoggerFactory.getLogger(TCPServerCommProvider.class.getSimpleName());
+    private final Set<Consumer<ConnectionEventArgs>> eventHandlers = new HashSet<>();
+
+    ServerSocket serverSocket;
+    Thread serverThread;
+
+    public TCPServerCommProvider() {
+    }
+
+    @Override
+    protected void doStart() throws SensorHubException {
+        var config = this.config.protocol;
+
+        //Start a thread to listen on the configured port
+        serverThread = new Thread(() -> {
+            try {
+                if (config.enableTLS) {
+                    var sslServerSocketFactory = (SSLServerSocketFactory) SSLServerSocketFactory.getDefault();
+                    try (var sslServerSocket = (SSLServerSocket) sslServerSocketFactory.createServerSocket(config.localPort)) {
+                        while (true) {
+                            var socket = sslServerSocket.accept();
+                            broadcast(socket.getInputStream(), socket.getOutputStream());
+                        }
+                    }
+                } else {
+                    serverSocket = new ServerSocket(config.localPort);
+                    while (true) {
+                        var socket = serverSocket.accept();
+                        broadcast(socket.getInputStream(), socket.getOutputStream());
+                    }
+                }
+            } catch (Exception e) {
+                log.error("TCPServerCommProvider error: " + e.getMessage());
+            }
+        });
+        serverThread.start();
+    }
+
+    @Override
+    protected void doStop() throws SensorHubException {
+        try {
+            if (serverSocket != null) {
+                serverSocket.close();
+            }
+            if (serverThread != null) {
+                serverThread.interrupt();
+            }
+        } catch (IOException e) {
+            log.error("TCPServerCommProvider error: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void cleanup() throws SensorHubException {
+    }
+
+    /**
+     * TCPServerCommProvider does not support getInputStream() or getOutputStream().
+     * Use onConnection() instead. This method will throw an UnsupportedOperationException.
+     */
+    @Override
+    public InputStream getInputStream() {
+        throw new UnsupportedOperationException("TCPServerCommProvider does not support getInputStream()");
+    }
+
+    /**
+     * TCPServerCommProvider does not support getInputStream() or getOutputStream().
+     * Use onConnection() instead. This method will throw an UnsupportedOperationException.
+     */
+    @Override
+    public OutputStream getOutputStream() {
+        throw new UnsupportedOperationException("TCPServerCommProvider does not support getOutputStream()");
+    }
+
+    /**
+     * Register code to be called when a connection is established.
+     * <p>
+     * Usage: commProvider.onConnection(args -> { ... })
+     * <p>
+     * Or: commProvider.onConnection(this::handleConnection)
+     *
+     * @param eventHandler code to be called when a connection is established
+     */
+    @Override
+    public void onConnection(Consumer<ConnectionEventArgs> eventHandler) {
+        eventHandlers.add(eventHandler);
+    }
+
+    /**
+     * Broadcast a connection to all registered event handlers.
+     *
+     * @param input  input stream
+     * @param output output stream
+     */
+    private void broadcast(InputStream input, OutputStream output) {
+        var args = new ConnectionEventArgs(input, output);
+        eventHandlers.forEach(eventHandler -> eventHandler.accept(args));
+    }
+}

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/comm/TCPServerCommProviderConfig.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/comm/TCPServerCommProviderConfig.java
@@ -1,0 +1,32 @@
+/***************************** BEGIN LICENSE BLOCK ***************************
+ The contents of this file are subject to the Mozilla Public License, v. 2.0.
+ If a copy of the MPL was not distributed with this file, You can obtain one
+ at http://mozilla.org/MPL/2.0/.
+
+ Software distributed under the License is distributed on an "AS IS" basis,
+ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ for the specific language governing rights and limitations under the License.
+
+ Copyright (C) 2023 Botts Innovative Research Inc. All Rights Reserved.
+ ******************************* END LICENSE BLOCK ***************************/
+
+package org.sensorhub.impl.comm;
+
+import org.sensorhub.api.comm.CommProviderConfig;
+import org.sensorhub.api.config.DisplayInfo;
+
+/**
+ * Configuration class for TCP/IP server connections
+ *
+ * @author Michael Elmore
+ * @since September 2023
+ */
+public class TCPServerCommProviderConfig extends CommProviderConfig<TCPServerConfig> {
+    @DisplayInfo(label = "Connection Options")
+    public RobustIPConnectionConfig connection = new RobustIPConnectionConfig();
+
+    public TCPServerCommProviderConfig() {
+        this.moduleClass = TCPCommProvider.class.getCanonicalName();
+        this.protocol = new TCPServerConfig();
+    }
+}

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/comm/TCPServerConfig.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/comm/TCPServerConfig.java
@@ -1,0 +1,44 @@
+/***************************** BEGIN LICENSE BLOCK ***************************
+ The contents of this file are subject to the Mozilla Public License, v. 2.0.
+ If a copy of the MPL was not distributed with this file, You can obtain one
+ at http://mozilla.org/MPL/2.0/.
+
+ Software distributed under the License is distributed on an "AS IS" basis,
+ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ for the specific language governing rights and limitations under the License.
+
+ Copyright (C) 2023 Botts Innovative Research Inc. All Rights Reserved.
+ ******************************* END LICENSE BLOCK ***************************/
+
+package org.sensorhub.impl.comm;
+
+import org.sensorhub.api.comm.ICommConfig;
+import org.sensorhub.api.config.DisplayInfo;
+import org.sensorhub.api.config.DisplayInfo.FieldType;
+import org.sensorhub.api.config.DisplayInfo.FieldType.Type;
+import org.sensorhub.api.config.DisplayInfo.Required;
+import org.sensorhub.api.config.DisplayInfo.ValueRange;
+
+
+/**
+ * Driver configuration options for the TCP/IP server network protocol
+ *
+ * @author Michael Elmore
+ * @since September 2023
+ */
+public class TCPServerConfig implements ICommConfig {
+    @DisplayInfo(desc = "Port number to listen on")
+    @ValueRange(max = 65535)
+    @Required
+    public int localPort;
+
+    @DisplayInfo(label = "User Name", desc = "Remote user name")
+    public String user;
+
+    @DisplayInfo(label = "Password", desc = "Remote password")
+    @FieldType(Type.PASSWORD)
+    public String password;
+
+    @DisplayInfo(desc = "Secure communications with SSL/TLS")
+    public boolean enableTLS;
+}

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/comm/UDPCommProvider.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/comm/UDPCommProvider.java
@@ -1,18 +1,23 @@
 /***************************** BEGIN LICENSE BLOCK ***************************
 
-The contents of this file are subject to the Mozilla Public License, v. 2.0.
-If a copy of the MPL was not distributed with this file, You can obtain one
-at http://mozilla.org/MPL/2.0/.
+ The contents of this file are subject to the Mozilla Public License, v. 2.0.
+ If a copy of the MPL was not distributed with this file, You can obtain one
+ at http://mozilla.org/MPL/2.0/.
 
-Software distributed under the License is distributed on an "AS IS" basis,
-WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
-for the specific language governing rights and limitations under the License.
- 
-Copyright (C) 2012-2015 Sensia Software LLC. All Rights Reserved.
- 
-******************************* END LICENSE BLOCK ***************************/
+ Software distributed under the License is distributed on an "AS IS" basis,
+ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ for the specific language governing rights and limitations under the License.
+
+ Copyright (C) 2012-2015 Sensia Software LLC. All Rights Reserved.
+ ******************************* END LICENSE BLOCK ***************************/
 
 package org.sensorhub.impl.comm;
+
+import org.sensorhub.api.comm.ICommProvider;
+import org.sensorhub.api.common.SensorHubException;
+import org.sensorhub.impl.module.AbstractModule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -23,11 +28,9 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.channels.Channels;
 import java.nio.channels.DatagramChannel;
-import org.sensorhub.api.comm.ICommProvider;
-import org.sensorhub.api.common.SensorHubException;
-import org.sensorhub.impl.module.AbstractModule;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Consumer;
 
 
 /**
@@ -38,83 +41,81 @@ import org.slf4j.LoggerFactory;
  * @author Alex Robin
  * @since Dec 12, 2015
  */
-public class UDPCommProvider extends AbstractModule<UDPCommProviderConfig> implements ICommProvider<UDPCommProviderConfig>
-{
+public class UDPCommProvider extends AbstractModule<UDPCommProviderConfig> implements ICommProvider<UDPCommProviderConfig> {
     static final Logger log = LoggerFactory.getLogger(UDPCommProvider.class.getSimpleName());
-    
+    private final Set<Consumer<ConnectionEventArgs>> listeners = new HashSet<>();
+
     DatagramChannel channel;
     InputStream is;
     OutputStream os;
-    
-    
+
+
     @Override
-    public InputStream getInputStream() throws IOException
-    {
+    public InputStream getInputStream() throws IOException {
         return is;
     }
 
 
     @Override
-    public OutputStream getOutputStream() throws IOException
-    {
+    public OutputStream getOutputStream() throws IOException {
         return os;
     }
 
 
     @Override
-    protected void doStart() throws SensorHubException
-    {        
+    protected void doStart() throws SensorHubException {
         UDPConfig config = this.config.protocol;
-        
-        try
-        {
+
+        try {
             SocketAddress localAddr = new InetSocketAddress(config.localPort);
-                        
+
             // if remote port is set to AUTO, use port the first UDP packet was sent from
             // to access this info we need to create a plain socket first
             int remotePort = config.remotePort;
-            if (remotePort <= 0)
-            {
-                try (DatagramSocket socket = new DatagramSocket(config.localPort))
-                {
+            if (remotePort <= 0) {
+                try (DatagramSocket socket = new DatagramSocket(config.localPort)) {
                     DatagramPacket udpPacket = new DatagramPacket(new byte[1], 1);
                     socket.receive(udpPacket);
                     remotePort = udpPacket.getPort();
-                }                
+                }
             }
-            
+
             SocketAddress remoteAddr = new InetSocketAddress(config.remoteHost, remotePort);
             channel = DatagramChannel.open();
             channel.bind(localAddr);
             channel.connect(remoteAddr);
             is = Channels.newInputStream(channel);
             os = Channels.newOutputStream(channel);
-        }
-        catch (Exception e)
-        {
+            broadcast(is, os);
+        } catch (Exception e) {
             throw new SensorHubException("Cannot setup UDP socket between local address " + config.localPort +
-                                         " and remote host " + config.remoteHost + ":" + config.remotePort, e);
+                    " and remote host " + config.remoteHost + ":" + config.remotePort, e);
         }
     }
 
 
     @Override
-    protected void doStop() throws SensorHubException
-    {
-        try
-        {
+    protected void doStop() throws SensorHubException {
+        try {
             channel.close();
-        }
-        catch (IOException e)
-        {
+        } catch (IOException e) {
             log.error("Cannot close datagram channel", e);
-        }        
+        }
     }
 
 
     @Override
-    public void cleanup() throws SensorHubException
-    {
+    public void cleanup() throws SensorHubException {
         // nothing to clean
+    }
+
+    @Override
+    public void onConnection(Consumer<ConnectionEventArgs> eventHandler) {
+        listeners.add(eventHandler);
+    }
+
+    private void broadcast(InputStream input, OutputStream output) {
+        var args = new ConnectionEventArgs(input, output);
+        listeners.forEach(listener -> listener.accept(args));
     }
 }

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/comm/UDPCommProvider.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/comm/UDPCommProvider.java
@@ -8,7 +8,7 @@
  WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
  for the specific language governing rights and limitations under the License.
 
- Copyright (C) 2012-2015 Sensia Software LLC. All Rights Reserved.
+ Copyright (C) 2012-2023 Sensia Software LLC. and Botts Innovative Research, Inc. All Rights Reserved.
  ******************************* END LICENSE BLOCK ***************************/
 
 package org.sensorhub.impl.comm;

--- a/sensorhub-core/src/main/resources/META-INF/services/org.sensorhub.api.module.IModuleProvider
+++ b/sensorhub-core/src/main/resources/META-INF/services/org.sensorhub.api.module.IModuleProvider
@@ -1,6 +1,7 @@
 org.sensorhub.impl.database.system.SystemDriverDatabaseDescriptor
 org.sensorhub.impl.comm.TCPCommModuleDescriptor
 org.sensorhub.impl.comm.UDPCommModuleDescriptor
+org.sensorhub.impl.comm.TCPServerCommModuleDescriptor
 org.sensorhub.impl.sensor.SensorSystemDescriptor
 org.sensorhub.impl.processing.SMLProcessDescriptor
 org.sensorhub.impl.security.BasicSecurityRealmDescriptor


### PR DESCRIPTION
I added a TCPServerCommProvider, which allows OSH to act as a server and send/receive data from a number of clients.

The TCP and UDP comm providers only allow a single connection, and so have been using getInputStream and getOutputStream. Since a server can have many connections, I had to implement a way to serve up the input and output stream, and do so in a way that all the comm providers can get access to the input and output streams regardless of whether server or client.

Now, rather than using getInputStream and getOutputStream, you can register code to call in onConnection:

```
commProvider.onConnection(args -> {
//do stuff with args.getInputStream() and getOutputStream()
})
```
or (alt syntax)
```
commProvider.onConnection(this::handleConnection)

...

handleConnection(ConnectionEventArgs args) {
//do stuff with args.getInputStream() and getOutputStream()
}
```

onConnection is called whenever a connection is established. For TCP and UDP comm providers, this connection always happens in start(), so the onConnection event should be registered before the comm module is started:
```
var moduleReg = getParentHub().getModuleRegistry();
commProvider = (ICommProvider<?>) moduleReg.loadSubModule(config.commSettings, true);
commProvider.onConnection(this::handleConnection);
commProvider.start();
```
In your onConnection method, you can handle getting the input and output streams the same way, regardless of whether OSH is acting as a client or server.

Please let me know if I need to make any changes, write unit tests, or anything else.