### PR TITLE
Detailed logging of invalid requests

### DIFF
--- a/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/ServiceErrors.java
+++ b/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/ServiceErrors.java
@@ -42,7 +42,13 @@ public class ServiceErrors
     
     public static InvalidRequestException invalidPayload(String msg)
     {
-        return new InvalidRequestException(ErrorCode.BAD_PAYLOAD, msg);
+        return invalidPayload(msg, null);
+    }
+    
+    
+    public static InvalidRequestException invalidPayload(String msg, Throwable cause)
+    {
+        return new InvalidRequestException(ErrorCode.BAD_PAYLOAD, msg, cause);
     }
     
     

--- a/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/resource/BaseResourceHandler.java
+++ b/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/resource/BaseResourceHandler.java
@@ -355,7 +355,7 @@ public abstract class BaseResourceHandler<K, V, F extends IQueryFilter, S extend
         }
         catch (ResourceParseException e)
         {
-            throw ServiceErrors.invalidPayload("Invalid payload: " + e.getMessage());
+            throw ServiceErrors.invalidPayload("Invalid payload: " + e.getMessage(), e);
         }
     }
     
@@ -399,7 +399,7 @@ public abstract class BaseResourceHandler<K, V, F extends IQueryFilter, S extend
         }
         catch (ResourceParseException e)
         {
-            throw ServiceErrors.invalidPayload("Invalid payload: " + e.getMessage());
+            throw ServiceErrors.invalidPayload("Invalid payload: " + e.getMessage(), e);
         }
         
         // update in datastore


### PR DESCRIPTION
Currently, some problems while parsing the payload generate fairly non-descript exceptions, where the message itself is not enough to diagnose the problem (see commit message for details). This PR ensures that on an InvalidRequestException, more details about the request and an exception backtrace is logged (see commit messages for details).