### PR TITLE
[CSAPI] Fix exception after parsing procedure XML

### DIFF
--- a/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/sensorml/SmlProcessBindingSmlXml.java
+++ b/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/sensorml/SmlProcessBindingSmlXml.java
@@ -74,7 +74,25 @@ public class SmlProcessBindingSmlXml<V extends ISmlFeature<?>> extends ResourceB
             if (!xmlReader.hasNext())
                 return null;
             
-            xmlReader.nextTag();
+            try
+            {
+                xmlReader.nextTag();
+            }
+            catch (XMLStreamException e)
+            {
+                // If the xmlReader is not advanced to END_OF_DOCUMENT
+                // before calling nextTag(), hasNext() above will still
+                // return true and nextTag() will fail. The best
+                // heuristic of this situation we have is to catch the
+                // exception and call hasNext. If so, that just means
+                // there was nothing (except maybe whitespace and
+                // comments) after the previous document, and that is
+                // not an exception.
+                if (!xmlReader.hasNext())
+                    return null;
+
+                throw e;
+            }
             var sml = smlBindings.readDescribedObject(xmlReader);
             
             if (sml instanceof Deployment)


### PR DESCRIPTION
When parsing the XML for a (new) procedure, BaseResourceHandler.create() calls SmlProcessBindingSmlXml.deserialize() repeatedly until there is no more data to be parsed.

However, the code that decides there is no more data did not actually work. After parsing the last object, the parser would still point at the last closing tag, so hasNext() would return true. However, the only event that then is still available is END_OF_DOCUMENT, which is not enough for nextTag(), which then throws.

In practice, this meant that an object to be added would be added as expected but then an exception was raised.

Note that this has not been tested with actually adding more than one object, since I could not figure out how to format multiple objects in a way they would be accepted at all (simply concatenating them produces "Illegal to have multiple roots").

This fixes #251