### PR TITLE
[CORE] Resolve issue #228 and #210

### DIFF
--- a/sensorhub-core/src/main/java/org/sensorhub/impl/system/DefaultSystemRegistry.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/system/DefaultSystemRegistry.java
@@ -263,7 +263,7 @@ public class DefaultSystemRegistry implements ISystemDriverRegistry
         // only insert mapping if not already registered by another database
         if (obsSystemDatabases.putIfAbsent(uid, db) != null)
             throw new IllegalStateException("System " + uid + " is already handled by another database");
-        
+
         // remove all entries from default state DB since it's now handled by another DB
         if (systemStateDb != null)
         {
@@ -282,7 +282,15 @@ public class DefaultSystemRegistry implements ISystemDriverRegistry
             systemStateDb.getDataStreamStore().removeEntries(dsFilter);
             systemStateDb.getCommandStreamStore().removeEntries(csFilter);
             var count = systemStateDb.getSystemDescStore().removeEntries(procFilter);
-            
+
+            /*
+            Replaces the driver's transaction handler.
+
+            There is already logic to replace the event handler if the driver handler is old, so
+            this simply replaces the SystemDriverTransactionHandler with one that uses the IObsSystemDatabase passed in this method.
+             */
+            register(getDriverHandler(uid).driver);
+
             if (count > 0)
                 log.info("Database #{} now handles system {}. Removing all records from state DB", db.getDatabaseNum(), uid);
         }

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/system/DefaultSystemRegistry.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/system/DefaultSystemRegistry.java
@@ -263,7 +263,6 @@ public class DefaultSystemRegistry implements ISystemDriverRegistry
         // only insert mapping if not already registered by another database
         if (obsSystemDatabases.putIfAbsent(uid, db) != null)
             throw new IllegalStateException("System " + uid + " is already handled by another database");
-
         // remove all entries from default state DB since it's now handled by another DB
         if (systemStateDb != null)
         {

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/system/DefaultSystemRegistry.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/system/DefaultSystemRegistry.java
@@ -263,6 +263,7 @@ public class DefaultSystemRegistry implements ISystemDriverRegistry
         // only insert mapping if not already registered by another database
         if (obsSystemDatabases.putIfAbsent(uid, db) != null)
             throw new IllegalStateException("System " + uid + " is already handled by another database");
+        
         // remove all entries from default state DB since it's now handled by another DB
         if (systemStateDb != null)
         {

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/system/DefaultSystemRegistry.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/system/DefaultSystemRegistry.java
@@ -278,13 +278,14 @@ public class DefaultSystemRegistry implements ISystemDriverRegistry
             var csFilter = new CommandStreamFilter.Builder()
                 .withSystems(procFilter)
                 .build();
+
+            // Replace driver's transaction handler so that new IObsSystemDatabase handles driver
+            systemStateDb.getSystemDescStore().selectEntries(procFilter).forEach(desc ->
+                    register(getDriverHandler(desc.getValue().getUniqueIdentifier()).driver));
             
             systemStateDb.getDataStreamStore().removeEntries(dsFilter);
             systemStateDb.getCommandStreamStore().removeEntries(csFilter);
             var count = systemStateDb.getSystemDescStore().removeEntries(procFilter);
-
-            // Replace driver's transaction handler so that new IObsSystemDatabase handles driver
-            register(getDriverHandler(uid).driver);
 
             if (count > 0)
                 log.info("Database #{} now handles system {}. Removing all records from state DB", db.getDatabaseNum(), uid);

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/system/DefaultSystemRegistry.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/system/DefaultSystemRegistry.java
@@ -280,7 +280,11 @@ public class DefaultSystemRegistry implements ISystemDriverRegistry
                 .build();
 
             // Replace driver's transaction handler so that new IObsSystemDatabase handles driver
-            systemStateDb.getSystemDescStore().selectEntries(procFilter).forEach(desc ->
+            var systemFilter = new SystemFilter.Builder()
+                .withUniqueIDs(uid)
+                .includeMembers(true)
+                .build();
+            systemStateDb.getSystemDescStore().selectEntries(systemFilter).forEach(desc ->
                     register(getDriverHandler(desc.getValue().getUniqueIdentifier()).driver));
             
             systemStateDb.getDataStreamStore().removeEntries(dsFilter);

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/system/DefaultSystemRegistry.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/system/DefaultSystemRegistry.java
@@ -283,12 +283,7 @@ public class DefaultSystemRegistry implements ISystemDriverRegistry
             systemStateDb.getCommandStreamStore().removeEntries(csFilter);
             var count = systemStateDb.getSystemDescStore().removeEntries(procFilter);
 
-            /*
-            Replaces the driver's transaction handler.
-
-            There is already logic to replace the event handler if the driver handler is old, so
-            this simply replaces the SystemDriverTransactionHandler with one that uses the IObsSystemDatabase passed in this method.
-             */
+            // Replace driver's transaction handler so that new IObsSystemDatabase handles driver
             register(getDriverHandler(uid).driver);
 
             if (count > 0)


### PR DESCRIPTION
Previously when adding a new System Driver Database, this database would be registered to the DefaultSystemRegistry's list of observational system databases, but would only be updated when the driver is restarted.

This fix uses register(getDriverHandler(uid).driver); to replace the driver's transaction handler. This single line works because there is a check in register(ISystemDriver driver) that "adds or updates" the entry, hence we can re-register it without issues.