### PR TITLE
[CORE] Resolve issue (#237) with SensorSystem submodules

### DIFF
--- a/sensorhub-core/src/main/java/org/sensorhub/impl/module/ModuleRegistry.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/module/ModuleRegistry.java
@@ -157,12 +157,8 @@ public class ModuleRegistry implements IModuleManager<IModule<?>>, IEventListene
         {
             if (module instanceof IDatabase || module instanceof IDataStore)
                 dataStores.add(module);
-            else {
-                // Load submodules of sensor system
-                if(module instanceof SensorSystem)
-                    ((SensorSystem) module).loadSubsystems();
+            else
                 otherModules.add(module);
-            }
         }
         
         // First start all datastore modules to ensure they are registered

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/module/ModuleRegistry.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/module/ModuleRegistry.java
@@ -51,9 +51,11 @@ import org.sensorhub.api.module.ModuleEvent;
 import org.sensorhub.api.module.ModuleEvent.ModuleState;
 import org.sensorhub.api.module.ModuleEvent.Type;
 import org.sensorhub.api.system.ISystemDriver;
+import org.sensorhub.api.system.ISystemGroupDriver;
 import org.sensorhub.impl.processing.AbstractProcessModule;
 import org.sensorhub.impl.sensor.AbstractSensorModule;
 import org.sensorhub.impl.sensor.SensorSystem;
+import org.sensorhub.impl.sensor.SensorSystemConfig;
 import org.sensorhub.utils.Async;
 import org.sensorhub.utils.FileUtils;
 import org.sensorhub.utils.MsgUtils;
@@ -155,8 +157,12 @@ public class ModuleRegistry implements IModuleManager<IModule<?>>, IEventListene
         {
             if (module instanceof IDatabase || module instanceof IDataStore)
                 dataStores.add(module);
-            else
+            else {
+                // Load submodules of sensor system
+                if(module instanceof SensorSystem)
+                    ((SensorSystem) module).loadSubsystems();
                 otherModules.add(module);
+            }
         }
         
         // First start all datastore modules to ensure they are registered

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/module/ModuleRegistry.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/module/ModuleRegistry.java
@@ -51,6 +51,9 @@ import org.sensorhub.api.module.ModuleEvent;
 import org.sensorhub.api.module.ModuleEvent.ModuleState;
 import org.sensorhub.api.module.ModuleEvent.Type;
 import org.sensorhub.api.system.ISystemDriver;
+import org.sensorhub.impl.processing.AbstractProcessModule;
+import org.sensorhub.impl.sensor.AbstractSensorModule;
+import org.sensorhub.impl.sensor.SensorSystem;
 import org.sensorhub.utils.Async;
 import org.sensorhub.utils.FileUtils;
 import org.sensorhub.utils.MsgUtils;
@@ -841,6 +844,20 @@ public class ModuleRegistry implements IModuleManager<IModule<?>>, IEventListene
             asyncExec.submit(() -> {
                 try
                 {
+                    if (module instanceof AbstractSensorModule) {
+                        var parent = ((AbstractSensorModule<?>)module).getParentSystem();
+                        if(parent instanceof SensorSystem) {
+                            ((SensorSystem) parent).updateSubsystemConfig(module.getConfiguration().id, config);
+                        }
+                    }
+
+                    if (module instanceof AbstractProcessModule) {
+                        var parent = ((AbstractProcessModule<?>)module).getParentSystem();
+                        if(parent instanceof SensorSystem) {
+                            ((SensorSystem) parent).updateSubsystemConfig(module.getConfiguration().id, config);
+                        }
+                    }
+
                     module.updateConfig(config);
                 }
                 catch (Exception e)

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/module/ModuleRegistry.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/module/ModuleRegistry.java
@@ -14,48 +14,23 @@ Copyright (C) 2012-2015 Sensia Software LLC. All Rights Reserved.
 
 package org.sensorhub.impl.module;
 
-import java.io.File;
-import java.lang.ref.WeakReference;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.function.Predicate;
+import com.google.common.collect.Sets;
 import org.sensorhub.api.ISensorHub;
 import org.sensorhub.api.ISensorHubConfig;
-import org.sensorhub.api.event.Event;
 import org.sensorhub.api.common.SensorHubException;
 import org.sensorhub.api.database.DatabaseConfig;
 import org.sensorhub.api.database.IDatabase;
 import org.sensorhub.api.datastore.IDataStore;
+import org.sensorhub.api.event.Event;
 import org.sensorhub.api.event.IEventListener;
 import org.sensorhub.api.event.IEventPublisher;
-import org.sensorhub.api.module.IModule;
-import org.sensorhub.api.module.IModuleConfigRepository;
-import org.sensorhub.api.module.IModuleManager;
-import org.sensorhub.api.module.IModuleProvider;
-import org.sensorhub.api.module.IModuleStateManager;
-import org.sensorhub.api.module.ModuleConfig;
-import org.sensorhub.api.module.ModuleEvent;
+import org.sensorhub.api.module.*;
 import org.sensorhub.api.module.ModuleEvent.ModuleState;
 import org.sensorhub.api.module.ModuleEvent.Type;
 import org.sensorhub.api.system.ISystemDriver;
-import org.sensorhub.api.system.ISystemGroupDriver;
 import org.sensorhub.impl.processing.AbstractProcessModule;
 import org.sensorhub.impl.sensor.AbstractSensorModule;
 import org.sensorhub.impl.sensor.SensorSystem;
-import org.sensorhub.impl.sensor.SensorSystemConfig;
 import org.sensorhub.utils.Async;
 import org.sensorhub.utils.FileUtils;
 import org.sensorhub.utils.MsgUtils;
@@ -63,7 +38,12 @@ import org.sensorhub.utils.NamedThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.vast.util.Asserts;
-import com.google.common.collect.Sets;
+
+import java.io.File;
+import java.lang.ref.WeakReference;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.function.Predicate;
 
 
 /**

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/sensor/SensorSystem.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/sensor/SensorSystem.java
@@ -310,14 +310,14 @@ public class SensorSystem extends AbstractSensorModule<SensorSystemConfig> imple
     public Map<String, ? extends IDataProducerModule<?>> getMembers()
     {
         return subsystems != null ?
-            subsystems.stream().collect(ImmutableMap.toImmutableMap(this::getMemberName, e -> e)) :
+            subsystems.stream().collect(ImmutableMap.toImmutableMap(this::getMemberId, e -> e)) :
             Collections.emptyMap();
     }
     
     
-    protected String getMemberName(IModule<?> member)
+    protected String getMemberId(IModule<?> member)
     {
-        return member.getName().toLowerCase().replaceAll("\\s+", "_");
+        return member.getLocalID();
     }
 
 }

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/sensor/SensorSystem.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/sensor/SensorSystem.java
@@ -80,22 +80,32 @@ public class SensorSystem extends AbstractSensorModule<SensorSystemConfig> imple
             }
         }
         
-        // load and init all subsystem modules
-        subsystems.clear();
-        for (SystemMember member: config.subsystems)
+        // init all subsystem modules
+        for(var module : subsystems)
         {
-            var module = (IDataProducerModule<?>)loadModule(member.config);
             if (module != null)
             {
                 try
                 {
-                    subsystems.add(module);
                     module.init();
                 }
                 catch (Exception e)
                 {
                     getLogger().error("Cannot initialize system component {}", MsgUtils.moduleString(config), e);
                 }
+            }
+        }
+    }
+
+    public void loadSubsystems() {
+        // Load all subsystem modules
+        subsystems.clear();
+        for (SystemMember member: config.subsystems)
+        {
+            var module = (IDataProducerModule<?>)loadModule(member.config);
+            if (module != null)
+            {
+                subsystems.add(module);
             }
         }
     }

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/sensor/SensorSystem.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/sensor/SensorSystem.java
@@ -106,10 +106,24 @@ public class SensorSystem extends AbstractSensorModule<SensorSystemConfig> imple
         var module = (IDataProducerModule<?>)loadModule(member.config);
         if (module == null)
             throw new SensorHubException("Error loading module");
-        
+
+        //member.config = module.getConfiguration();
         config.subsystems.add(member);
         subsystems.add(module);
         return module;
+    }
+
+    public void updateSubsystemConfig(String id, ModuleConfig config) throws SensorHubException {
+        Asserts.checkNotNull(id, "id");
+
+        // Find member and update config
+        var configIterator = this.config.subsystems.iterator();
+        while(configIterator.hasNext()) {
+            var memberConfig = configIterator.next();
+            if(id.equals(memberConfig.config.id)) {
+                memberConfig.config = config;
+            }
+        }
     }
     
     

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/sensor/SensorSystem.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/sensor/SensorSystem.java
@@ -57,7 +57,20 @@ public class SensorSystem extends AbstractSensorModule<SensorSystemConfig> imple
     private static final String URN_PREFIX = "urn:";
     
     Collection<IDataProducerModule<?>> subsystems = new ArrayList<>();
-    
+
+    protected SensorSystem() {
+        super();
+        // Load all subsystem modules
+        subsystems.clear();
+        for (SystemMember member: config.subsystems)
+        {
+            var module = (IDataProducerModule<?>)loadModule(member.config);
+            if (module != null)
+            {
+                subsystems.add(module);
+            }
+        }
+    }
     
     @Override
     protected void doInit() throws SensorHubException
@@ -96,20 +109,6 @@ public class SensorSystem extends AbstractSensorModule<SensorSystemConfig> imple
             }
         }
     }
-
-    public void loadSubsystems() {
-        // Load all subsystem modules
-        subsystems.clear();
-        for (SystemMember member: config.subsystems)
-        {
-            var module = (IDataProducerModule<?>)loadModule(member.config);
-            if (module != null)
-            {
-                subsystems.add(module);
-            }
-        }
-    }
-    
     
     public IModule<?> addSubsystem(SystemMember member) throws SensorHubException
     {

--- a/sensorhub-webui-core/src/main/java/org/sensorhub/ui/ModuleInstanceSelectionPopup.java
+++ b/sensorhub-webui-core/src/main/java/org/sensorhub/ui/ModuleInstanceSelectionPopup.java
@@ -74,7 +74,8 @@ public class ModuleInstanceSelectionPopup extends Window
                     var subModules = ((SensorSystem) module).getMembers();
                     for(IDataProducerModule<?> member : subModules.values())
                     {
-                        if(moduleType.isAssignableFrom(member.getClass())) {
+                        if(moduleType.isAssignableFrom(member.getClass()))
+                        {
                             Object memberID = table.addItem(new Object[]{
                                     member.getName(),
                                     member.getLocalID()}, null);

--- a/sensorhub-webui-core/src/main/java/org/sensorhub/ui/ModuleInstanceSelectionPopup.java
+++ b/sensorhub-webui-core/src/main/java/org/sensorhub/ui/ModuleInstanceSelectionPopup.java
@@ -14,21 +14,18 @@ Copyright (C) 2012-2015 Sensia Software LLC. All Rights Reserved.
 
 package org.sensorhub.ui;
 
+import java.util.HashMap;
+import java.util.Map;
+import org.sensorhub.api.common.SensorHubException;
+import org.sensorhub.api.module.IModule;
+import org.sensorhub.ui.api.UIConstants;
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.Button;
+import com.vaadin.v7.ui.Table;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
 import com.vaadin.ui.Window;
 import com.vaadin.ui.Button.ClickEvent;
-import com.vaadin.v7.ui.TreeTable;
-import org.sensorhub.api.common.SensorHubException;
-import org.sensorhub.api.data.IDataProducerModule;
-import org.sensorhub.api.module.IModule;
-import org.sensorhub.impl.sensor.SensorSystem;
-import org.sensorhub.ui.api.UIConstants;
-
-import java.util.HashMap;
-import java.util.Map;
 
 
 @SuppressWarnings("serial")
@@ -49,7 +46,7 @@ public class ModuleInstanceSelectionPopup extends Window
         layout.setSpacing(true);
         
         // generate table with module list
-        final TreeTable table = new TreeTable();
+        final Table table = new Table();
         table.setSizeFull();
         table.setSelectable(true);
         table.setColumnReorderingAllowed(true);        
@@ -69,26 +66,6 @@ public class ModuleInstanceSelectionPopup extends Window
                         module.getName(),
                         module.getLocalID()}, null);
                 moduleMap.put(id, module);
-                if(module instanceof SensorSystem)
-                {
-                    var subModules = ((SensorSystem) module).getMembers();
-                    for(IDataProducerModule<?> member : subModules.values())
-                    {
-                        if(moduleType.isAssignableFrom(member.getClass()))
-                        {
-                            Object memberID = table.addItem(new Object[]{
-                                    member.getName(),
-                                    member.getLocalID()}, null);
-                            moduleMap.put(memberID, member);
-                            table.setParent(memberID, id);
-                            table.setChildrenAllowed(memberID, false);
-                        }
-                    }
-                }
-                else
-                {
-                    table.setChildrenAllowed(id, false);
-                }
             }
         }
         layout.addComponent(table);

--- a/sensorhub-webui-core/src/main/java/org/sensorhub/ui/ModuleInstanceSelectionPopup.java
+++ b/sensorhub-webui-core/src/main/java/org/sensorhub/ui/ModuleInstanceSelectionPopup.java
@@ -14,18 +14,21 @@ Copyright (C) 2012-2015 Sensia Software LLC. All Rights Reserved.
 
 package org.sensorhub.ui;
 
-import java.util.HashMap;
-import java.util.Map;
-import org.sensorhub.api.common.SensorHubException;
-import org.sensorhub.api.module.IModule;
-import org.sensorhub.ui.api.UIConstants;
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.Button;
-import com.vaadin.v7.ui.Table;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.VerticalLayout;
 import com.vaadin.ui.Window;
 import com.vaadin.ui.Button.ClickEvent;
+import com.vaadin.v7.ui.TreeTable;
+import org.sensorhub.api.common.SensorHubException;
+import org.sensorhub.api.data.IDataProducerModule;
+import org.sensorhub.api.module.IModule;
+import org.sensorhub.impl.sensor.SensorSystem;
+import org.sensorhub.ui.api.UIConstants;
+
+import java.util.HashMap;
+import java.util.Map;
 
 
 @SuppressWarnings("serial")
@@ -46,7 +49,7 @@ public class ModuleInstanceSelectionPopup extends Window
         layout.setSpacing(true);
         
         // generate table with module list
-        final Table table = new Table();
+        final TreeTable table = new TreeTable();
         table.setSizeFull();
         table.setSelectable(true);
         table.setColumnReorderingAllowed(true);        
@@ -66,6 +69,23 @@ public class ModuleInstanceSelectionPopup extends Window
                         module.getName(),
                         module.getLocalID()}, null);
                 moduleMap.put(id, module);
+                if(module instanceof SensorSystem)
+                {
+                    var subModules = ((SensorSystem) module).getMembers();
+                    for(IDataProducerModule<?> member : subModules.values())
+                    {
+                        Object memberID = table.addItem(new Object[] {
+                                member.getName(),
+                                member.getLocalID()}, null);
+                        moduleMap.put(memberID, member);
+                        table.setParent(memberID, id);
+                        table.setChildrenAllowed(memberID, false);
+                    }
+                }
+                else
+                {
+                    table.setChildrenAllowed(id, false);
+                }
             }
         }
         layout.addComponent(table);

--- a/sensorhub-webui-core/src/main/java/org/sensorhub/ui/ModuleInstanceSelectionPopup.java
+++ b/sensorhub-webui-core/src/main/java/org/sensorhub/ui/ModuleInstanceSelectionPopup.java
@@ -74,12 +74,14 @@ public class ModuleInstanceSelectionPopup extends Window
                     var subModules = ((SensorSystem) module).getMembers();
                     for(IDataProducerModule<?> member : subModules.values())
                     {
-                        Object memberID = table.addItem(new Object[] {
-                                member.getName(),
-                                member.getLocalID()}, null);
-                        moduleMap.put(memberID, member);
-                        table.setParent(memberID, id);
-                        table.setChildrenAllowed(memberID, false);
+                        if(moduleType.isAssignableFrom(member.getClass())) {
+                            Object memberID = table.addItem(new Object[]{
+                                    member.getName(),
+                                    member.getLocalID()}, null);
+                            moduleMap.put(memberID, member);
+                            table.setParent(memberID, id);
+                            table.setChildrenAllowed(memberID, false);
+                        }
                     }
                 }
                 else


### PR DESCRIPTION
Currently, general problems with the SensorSystem module can be reduced to two main issues.

# Issue 1
Sensor system submodules' configs do not save when the sensor system's config is saved.
## Reason
Sensor system configs include a list of submodule configs. When a submodule's config is updated, the sensor system's config for that submodule does **not** get updated. This is because the AdminUI submits a new instance of the submodule's config, but the sensor system's config for this submodule is not updated to the new instance.
## Solution
My solution involves an additional method to replace the sensor system's config for the submodule, when the submodule is configured. Ideally, updates to a module's configuration should be listened to by the parent system, if one exists.
---
# Issue 2
Sensor system submodules will not show up unless the sensor system has auto-start enabled.
## Reason
Sensor system submodules are only loaded upon initialization of sensor system itself. This is an issue because submodules will not show up in the UI unless they are loaded by the module registry. Modules that are loaded without auto-start will **not** be initialized. This is not a problem unless you are loading submodules in the initialization procedure, which is the case for this module.
## Solution
My solution is to load all submodules of a sensor system when the sensor system itself is loaded, so the module only has to initialize them when the sensor system initializes. Ideally, I believe the ISystemGroupDriver should have a more uniform definition for its ```getMembers()``` method, so that members can be loaded upon parent system load, or an abstract ```loadSubsystems()``` or ```loadMembers()``` should be implemented for each ISystemGroupDriver.