### PR TITLE
Add deployment name configurable option and display in about panel

### DIFF
--- a/sensorhub-webui-core/src/main/java/org/sensorhub/ui/AdminUI.java
+++ b/sensorhub-webui-core/src/main/java/org/sensorhub/ui/AdminUI.java
@@ -201,7 +201,7 @@ public class AdminUI extends com.vaadin.ui.UI implements UIConstants
         Component header = buildHeader();
         leftPane.addComponent(header);
         leftPane.setExpandRatio(header, 0);
-        
+
         // toolbar
         Component toolbar = buildToolbar();
         leftPane.addComponent(toolbar);
@@ -306,7 +306,6 @@ public class AdminUI extends com.vaadin.ui.UI implements UIConstants
         }
     }
     
-    
     protected Component buildHeader()
     {
         HorizontalLayout header = new HorizontalLayout();
@@ -328,7 +327,7 @@ public class AdminUI extends com.vaadin.ui.UI implements UIConstants
         header.addComponent(title);
         header.setExpandRatio(title, 1);
         header.setComponentAlignment(title, Alignment.MIDDLE_LEFT);
-        
+
         // about icon
         Button about = new Button();
         about.addStyleName(STYLE_QUIET);
@@ -356,6 +355,12 @@ public class AdminUI extends com.vaadin.ui.UI implements UIConstants
                                                " target=\"_blank\">Mozilla Public License v2.0</a>", ContentMode.HTML));
                 content.addComponent(new Label("<b>Version:</b> " + (version != null ? version: "?"), ContentMode.HTML));
                 content.addComponent(new Label("<b>Build Number:</b> " + (buildNumber != null ? buildNumber: "?"), ContentMode.HTML));
+
+                // If the config has a friendly node name
+                if (adminModule.getConfiguration().deploymentName != null && !adminModule.getConfiguration().deploymentName.isEmpty()) {
+
+                    content.addComponent(new Label("<b>Deployment Name:</b> " + adminModule.getConfiguration().deploymentName, ContentMode.HTML));
+                }
                 popup.setContent(content);
                 addWindow(popup);
             }

--- a/sensorhub-webui-core/src/main/java/org/sensorhub/ui/AdminUIConfig.java
+++ b/sensorhub-webui-core/src/main/java/org/sensorhub/ui/AdminUIConfig.java
@@ -34,7 +34,9 @@ public class AdminUIConfig extends ModuleConfig
     
     
     public List<CustomUIConfig> customForms = new ArrayList<CustomUIConfig>();
-    
+
+    @DisplayInfo(desc="A human readable friendly identifier for the deployment")
+    public String deploymentName = null;
     
     public AdminUIConfig()
     {


### PR DESCRIPTION
Adds a configurable option to the about panel, if configured, to display an identifier for the node akin to a deployment name indicating something meaningful to the end user about the nodes deployment vs. other nodes they may also have access to.