### PR TITLE
Fix sensorsystem issues

### DIFF
--- a/sensorhub-core/src/main/java/org/sensorhub/impl/module/ModuleRegistry.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/module/ModuleRegistry.java
@@ -51,7 +51,6 @@ import org.sensorhub.api.module.ModuleEvent;
 import org.sensorhub.api.module.ModuleEvent.ModuleState;
 import org.sensorhub.api.module.ModuleEvent.Type;
 import org.sensorhub.api.system.ISystemDriver;
-import org.sensorhub.impl.sensor.SensorSystem;
 import org.sensorhub.utils.Async;
 import org.sensorhub.utils.FileUtils;
 import org.sensorhub.utils.MsgUtils;
@@ -842,17 +841,6 @@ public class ModuleRegistry implements IModuleManager<IModule<?>>, IEventListene
             asyncExec.submit(() -> {
                 try
                 {
-                    // If module has a parent system, we want to update the subsystem config of that module in the sensor system
-                    if(module instanceof ISystemDriver && ((ISystemDriver)module).getParentSystem() instanceof SensorSystem) {
-                        var parentConfig = ((SensorSystem) ((ISystemDriver) module).getParentSystem()).getConfiguration();
-
-                        // Find member and update config
-                        for (org.sensorhub.impl.sensor.SensorSystemConfig.SystemMember memberConfig : parentConfig.subsystems) {
-                            if (module.getConfiguration().id.equals(memberConfig.config.id)) {
-                                memberConfig.config = config;
-                            }
-                        }
-                    }
                     module.updateConfig(config);
                 }
                 catch (Exception e)

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/processing/AbstractProcessModule.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/processing/AbstractProcessModule.java
@@ -115,11 +115,14 @@ public abstract class AbstractProcessModule<T extends ProcessConfig> extends Abs
     protected void beforeStart() throws SensorHubException
     {
         super.beforeStart();
-        
+
+        if(getParentSystem() != null && !getParentSystem().isEnabled())
+            throw new ProcessingException("Parent system must be started");
+
         // register sensor with registry if attached to a hub and we have no parent
         try
         {
-            if (hasParentHub() && getParentHub().getSystemDriverRegistry() != null)
+            if (hasParentHub() && getParentHub().getSystemDriverRegistry() != null && (getParentSystem() == null || getParentSystem().isEnabled()))
                 getParentHub().getSystemDriverRegistry().register(this).get(); // for now, block here until init is also async
         }
         catch (InterruptedException e)

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/processing/AbstractProcessWrapperModule.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/processing/AbstractProcessWrapperModule.java
@@ -81,10 +81,13 @@ public abstract class AbstractProcessWrapperModule<T extends ProcessConfig> exte
     {
         super.beforeStart();
         
+        if(getParentSystem() != null && !getParentSystem().isEnabled())
+            throw new ProcessingException("Parent system must be started");
+
         // register sensor with registry if attached to a hub and we have no parent
         try
         {
-            if (hasParentHub() && getParentHub().getSystemDriverRegistry() != null)
+            if (hasParentHub() && getParentHub().getSystemDriverRegistry() != null && (getParentSystem() == null || getParentSystem().isEnabled()))
                 getParentHub().getSystemDriverRegistry().register(this).get(); // for now, block here until init is also async
         }
         catch (InterruptedException e)

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/sensor/AbstractSensorModule.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/sensor/AbstractSensorModule.java
@@ -209,11 +209,14 @@ public abstract class AbstractSensorModule<T extends SensorConfig> extends Abstr
     protected void beforeStart() throws SensorHubException
     {
         super.beforeStart();
-        
+
+        if(getParentSystem() != null && !getParentSystem().isEnabled())
+            throw new SensorException("Parent system must be started");
+
         // register sensor with registry if attached to a hub and we have no parent
         try
         {
-            if (hasParentHub() && getParentHub().getSystemDriverRegistry() != null)
+            if (hasParentHub() && getParentHub().getSystemDriverRegistry() != null && (getParentSystem() == null || getParentSystem().isEnabled()))
                 getParentHub().getSystemDriverRegistry().register(this).get(); // for now, block here until init is also async
         }
         catch (InterruptedException e)

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/sensor/SensorSystem.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/sensor/SensorSystem.java
@@ -309,14 +309,14 @@ public class SensorSystem extends AbstractSensorModule<SensorSystemConfig> imple
     public Map<String, ? extends IDataProducerModule<?>> getMembers()
     {
         return subsystems != null ?
-            subsystems.stream().collect(ImmutableMap.toImmutableMap(this::getMemberName, e -> e)) :
+            subsystems.stream().collect(ImmutableMap.toImmutableMap(this::getMemberId, e -> e)) :
             Collections.emptyMap();
     }
     
     
-    protected String getMemberName(IModule<?> member)
+    protected String getMemberId(IModule<?> member)
     {
-        return member.getName().toLowerCase().replaceAll("\\s+", "_");
+        return member.getLocalID();
     }
 
 }

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/sensor/SensorSystem.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/sensor/SensorSystem.java
@@ -199,21 +199,25 @@ public class SensorSystem extends AbstractSensorModule<SensorSystemConfig> imple
 
 
     @Override
-    protected void doStart() throws SensorHubException
-    {
-        for (var member: subsystems)
-        {
-            try
+    protected void setState(ModuleState newState) {
+        super.setState(newState);
+
+        // Ensure that autoStart starts modules after Sensor System is enabled
+        if (newState == ModuleState.STARTED) {
+            for (var member: subsystems)
             {
-                if (member.getConfiguration().autoStart)
+                try
                 {
-                    member.waitForState(ModuleState.INITIALIZED, 10000);
-                    member.start();
+                    if (member.getConfiguration().autoStart)
+                    {
+                        member.waitForState(ModuleState.INITIALIZED, 10000);
+                        member.start();
+                    }
                 }
-            }
-            catch (Exception e)
-            {
-                reportError("Cannot start subsystem " + MsgUtils.moduleString(member), e);
+                catch (Exception e)
+                {
+                    reportError("Cannot start subsystem " + MsgUtils.moduleString(member), e);
+                }
             }
         }
     }

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/sensor/SensorSystem.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/sensor/SensorSystem.java
@@ -175,8 +175,13 @@ public class SensorSystem extends AbstractSensorModule<SensorSystemConfig> imple
             {
                 var moduleConfig = ((ModuleEvent)e).getModule().getConfiguration();
                 for(SystemMember member : config.subsystems)
+                {
                     if(moduleConfig.id.equals(member.config.id))
+                    {
                         member.config = moduleConfig;
+                        break;
+                    }
+                }
             }
         }
     }

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/sensor/SensorSystem.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/sensor/SensorSystem.java
@@ -58,20 +58,7 @@ public class SensorSystem extends AbstractSensorModule<SensorSystemConfig> imple
     
     Collection<IDataProducerModule<?>> subsystems = new ArrayList<>();
 
-    public SensorSystem() {
-        super();
-        // Load all subsystem modules
-        subsystems.clear();
-        if(config != null) {
-            for (SystemMember member : config.subsystems) {
-                var module = (IDataProducerModule<?>) loadModule(member.config);
-                if (module != null) {
-                    subsystems.add(module);
-                }
-            }
-        }
-    }
-    
+
     @Override
     protected void doInit() throws SensorHubException
     {

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/system/DefaultSystemRegistry.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/system/DefaultSystemRegistry.java
@@ -269,6 +269,7 @@ public class DefaultSystemRegistry implements ISystemDriverRegistry
         {
             var procFilter = new SystemFilter.Builder()
                 .withUniqueIDs(uid)
+                .withNoParent()
                 .build();
             
             var dsFilter = new DataStreamFilter.Builder()
@@ -280,11 +281,7 @@ public class DefaultSystemRegistry implements ISystemDriverRegistry
                 .build();
 
             // Replace driver's transaction handler so that new IObsSystemDatabase handles driver
-            var systemFilter = new SystemFilter.Builder()
-                .withUniqueIDs(uid)
-                .includeMembers(true)
-                .build();
-            systemStateDb.getSystemDescStore().selectEntries(systemFilter).forEach(desc ->
+            systemStateDb.getSystemDescStore().selectEntries(procFilter).forEach(desc ->
                     register(getDriverHandler(desc.getValue().getUniqueIdentifier()).driver));
             
             systemStateDb.getDataStreamStore().removeEntries(dsFilter);

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/system/DefaultSystemRegistry.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/system/DefaultSystemRegistry.java
@@ -269,7 +269,7 @@ public class DefaultSystemRegistry implements ISystemDriverRegistry
         {
             var procFilter = new SystemFilter.Builder()
                 .withUniqueIDs(uid)
-                .withNoParent()
+                .includeMembers(true)
                 .build();
             
             var dsFilter = new DataStreamFilter.Builder()
@@ -280,13 +280,18 @@ public class DefaultSystemRegistry implements ISystemDriverRegistry
                 .withSystems(procFilter)
                 .build();
 
+            var topLevelSystemsFilter = new SystemFilter.Builder()
+                .withUniqueIDs(uid)
+                .withNoParent()
+                .build();
+
             // Replace driver's transaction handler so that new IObsSystemDatabase handles driver
-            systemStateDb.getSystemDescStore().selectEntries(procFilter).forEach(desc ->
+            systemStateDb.getSystemDescStore().selectEntries(topLevelSystemsFilter).forEach(desc ->
                     register(getDriverHandler(desc.getValue().getUniqueIdentifier()).driver));
-            
+
             systemStateDb.getDataStreamStore().removeEntries(dsFilter);
             systemStateDb.getCommandStreamStore().removeEntries(csFilter);
-            var count = systemStateDb.getSystemDescStore().removeEntries(procFilter);
+            var count = systemStateDb.getSystemDescStore().removeEntries(topLevelSystemsFilter);
 
             if (count > 0)
                 log.info("Database #{} now handles system {}. Removing all records from state DB", db.getDatabaseNum(), uid);

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/system/SystemDriverTransactionHandler.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/system/SystemDriverTransactionHandler.java
@@ -100,8 +100,7 @@ class SystemDriverTransactionHandler extends SystemTransactionHandler implements
         {
             for (var member: ((ISystemGroupDriver<?>)driver).getMembers().values())
             {
-                if (!(member instanceof IModule<?>)) // don't register submodules as they'll register themselves
-                    doRegisterMember(member, driver.getCurrentDescription().getValidTime());
+                doRegisterMember(member, driver.getCurrentDescription().getValidTime());
             }
         }
 

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/system/SystemDriverTransactionHandler.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/system/SystemDriverTransactionHandler.java
@@ -187,7 +187,6 @@ class SystemDriverTransactionHandler extends SystemTransactionHandler implements
     {
         Asserts.checkNotNull(driver, ISystemDriver.class);
         var uid = OshAsserts.checkValidUID(driver.getUniqueIdentifier());
-        boolean isNew = false;
         
         var procWrapper = new SystemWrapper(driver.getCurrentDescription())
             .hideOutputs()
@@ -198,17 +197,23 @@ class SystemDriverTransactionHandler extends SystemTransactionHandler implements
             procWrapper.defaultToValidTime(validTime);
         else
             procWrapper.defaultToValidFromNow();
-        
+
         // add or update existing system entry
         var newMemberHandler = (SystemDriverTransactionHandler)addOrUpdateMember(procWrapper);
-        
+
         // replace and cleanup old handler
         var oldMemberHandler = memberHandlers.get(uid);
-        if (oldMemberHandler != null)
+        boolean isNew = oldMemberHandler == null;
+        if (!isNew)
         {
-            driver.unregisterListener(oldMemberHandler);
-            isNew = false;
+            // only allow same member driver to re-register with same UID
+            ISystemDriver registeredDriver = oldMemberHandler.driver;
+            if (registeredDriver != null && registeredDriver != driver)
+                throw new IllegalArgumentException("A subsystem with UID " + uid + " is already registered");
+
+            driver.unregisterListener(memberHandlers.get(uid));
         }
+
         memberHandlers.put(uid, newMemberHandler);
 
         // register/update driver sub-components
@@ -462,7 +467,7 @@ class SystemDriverTransactionHandler extends SystemTransactionHandler implements
             {
                 var driverUid = driver.getUniqueIdentifier();
                 var eventUid = ((SystemEvent) e).getSystemUID();
-                
+
                 // assign internal ID before event is dispatched
                 ((SystemEvent)e).assignSystemID(sysKey.getInternalID());
                 


### PR DESCRIPTION
This fixes 2 main issues and amends a minor issue:
## Configuration of submodules will not save
- Problem: SensorSystem config does not get updated when subsystem config is updated.
- Solution: When SensorSystem receives a ```CONFIG_CHANGED``` module event, it will update the config with the new subsystem config.

## Submodules do not show up when OSH starts
- Problem: Submodules do not load until initialization of the SensorSystem, so they won't load unless started or module's autostart is enabled.
- Solution: Load submodules when SensorSystem loads. **NOTE** Cannot do this in SensorSystem constructor as the new object does not have config to read subsystems from. So, subsystems are loaded when the SensorSystem receives a SensorSystemConfig.

## Minor Changes for System driver database
- Update the SystemFilter to search for ```withNoParent()``` systems to enforce parent system managing subsystems
- Allow submodules to update their driverhandler if needed. ```doRegisterMember()``` checks if submodule already has a handler and updates it if so