### PR TITLE
Allow more flexible database purge policy configuration

### DIFF
--- a/sensorhub-core/src/main/java/org/sensorhub/api/database/IObsSystemDbAutoPurgePolicy.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/api/database/IObsSystemDbAutoPurgePolicy.java
@@ -16,6 +16,7 @@ package org.sensorhub.api.database;
 
 import org.slf4j.Logger;
 
+import java.util.Collection;
 
 /**
  * <p>
@@ -35,6 +36,7 @@ public interface IObsSystemDbAutoPurgePolicy
      * for this aging policy
      * @param db
      * @param log
+     * @param systemUIDs
      */
-    public void trimStorage(IObsSystemDatabase db, Logger log); 
+    public void trimStorage(IObsSystemDatabase db, Logger log, Collection<String> systemUIDs);
 }

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/database/system/HistoricalObsAutoPurgeConfig.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/database/system/HistoricalObsAutoPurgeConfig.java
@@ -17,6 +17,8 @@ package org.sensorhub.impl.database.system;
 import org.sensorhub.api.config.DisplayInfo;
 import org.sensorhub.api.database.IObsSystemDbAutoPurgePolicy;
 
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * <p>
@@ -36,6 +38,10 @@ public abstract class HistoricalObsAutoPurgeConfig
     @DisplayInfo(label="Purge Execution Period", desc="Execution period of the purge policy (in seconds)")
     public double purgePeriod = 3600.0;
 
-    
+    @DisplayInfo.Required
+    @DisplayInfo.FieldType(DisplayInfo.FieldType.Type.SYSTEM_UID)
+    @DisplayInfo(label="System UIDs", desc="Unique IDs of system drivers to purge")
+    public List<String> systemUIDs = new ArrayList<>(List.of("*"));
+
     public abstract IObsSystemDbAutoPurgePolicy getPolicy();
 }

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/database/system/SystemDriverDatabase.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/database/system/SystemDriverDatabase.java
@@ -80,6 +80,9 @@ public class SystemDriverDatabase extends AbstractModule<SystemDriverDatabaseCon
         {
             throw new DataStoreException("Cannot instantiate underlying database " + config.dbConfig.moduleClass, e);
         }
+
+        if(!config.autoPurgeConfig.isEmpty())
+            autoPurgeTimer = new Timer();
         
         // start auto-purge timer thread if policy is specified and enabled
         for(var autoPurgeConfig : config.autoPurgeConfig)
@@ -88,7 +91,6 @@ public class SystemDriverDatabase extends AbstractModule<SystemDriverDatabaseCon
             {
                 var uids = Collections.unmodifiableCollection(autoPurgeConfig.systemUIDs);
                 final IObsSystemDbAutoPurgePolicy policy = autoPurgeConfig.getPolicy();
-                autoPurgeTimer = new Timer();
                 TimerTask task = new TimerTask() {
                     public void run()
                     {

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/database/system/SystemDriverDatabase.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/database/system/SystemDriverDatabase.java
@@ -84,13 +84,14 @@ public class SystemDriverDatabase extends AbstractModule<SystemDriverDatabaseCon
         // start auto-purge timer thread if policy is specified and enabled
         if (config.autoPurgeConfig != null && config.autoPurgeConfig.enabled)
         {
+            var uids = Collections.unmodifiableCollection(config.autoPurgeConfig.systemUIDs);
             final IObsSystemDbAutoPurgePolicy policy = config.autoPurgeConfig.getPolicy();
             autoPurgeTimer = new Timer();
             TimerTask task = new TimerTask() {
                 public void run()
                 {
                     if (!db.isReadOnly())
-                        policy.trimStorage(db, logger);
+                        policy.trimStorage(db, logger, uids);
                 }
             };
             

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/database/system/SystemDriverDatabase.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/database/system/SystemDriverDatabase.java
@@ -82,20 +82,23 @@ public class SystemDriverDatabase extends AbstractModule<SystemDriverDatabaseCon
         }
         
         // start auto-purge timer thread if policy is specified and enabled
-        if (config.autoPurgeConfig != null && config.autoPurgeConfig.enabled)
+        for(var autoPurgeConfig : config.autoPurgeConfig)
         {
-            var uids = Collections.unmodifiableCollection(config.autoPurgeConfig.systemUIDs);
-            final IObsSystemDbAutoPurgePolicy policy = config.autoPurgeConfig.getPolicy();
-            autoPurgeTimer = new Timer();
-            TimerTask task = new TimerTask() {
-                public void run()
-                {
-                    if (!db.isReadOnly())
-                        policy.trimStorage(db, logger, uids);
-                }
-            };
-            
-            autoPurgeTimer.schedule(task, 0, (long)(config.autoPurgeConfig.purgePeriod*1000));
+            if (autoPurgeConfig != null && autoPurgeConfig.enabled)
+            {
+                var uids = Collections.unmodifiableCollection(autoPurgeConfig.systemUIDs);
+                final IObsSystemDbAutoPurgePolicy policy = autoPurgeConfig.getPolicy();
+                autoPurgeTimer = new Timer();
+                TimerTask task = new TimerTask() {
+                    public void run()
+                    {
+                        if (!db.isReadOnly())
+                            policy.trimStorage(db, logger, uids);
+                    }
+                };
+
+                autoPurgeTimer.schedule(task, 0, (long)(autoPurgeConfig.purgePeriod*1000));
+            }
         }
     }
     

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/database/system/SystemDriverDatabaseConfig.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/database/system/SystemDriverDatabaseConfig.java
@@ -14,6 +14,8 @@ Copyright (C) 2019 Sensia Software LLC. All Rights Reserved.
 
 package org.sensorhub.impl.database.system;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import org.sensorhub.api.config.DisplayInfo;
@@ -46,7 +48,7 @@ public class SystemDriverDatabaseConfig extends DatabaseConfig
     
     
     @DisplayInfo(label="Automatic Purge Policy", desc="Policy for automatically purging historical data")
-    public HistoricalObsAutoPurgeConfig autoPurgeConfig;
+    public List<HistoricalObsAutoPurgeConfig> autoPurgeConfig = new ArrayList<>();
     
 
     @DisplayInfo(desc="Minimum period between database commits (in ms)")


### PR DESCRIPTION
This change updates the database purge policy to be a list of purge policies, for the purpose of targeting specific systems with specific purge periods and max record ages. This improves the flexibility of database purging and allows for databases that are easier to maintain.