### PR TITLE
Use TCP configuration options for connection timeout and retry attempts

### DIFF
--- a/sensorhub-core/src/main/java/org/sensorhub/impl/comm/TCPCommProvider.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/comm/TCPCommProvider.java
@@ -70,32 +70,32 @@ public class TCPCommProvider extends AbstractModule<TCPCommProviderConfig> imple
     protected void doStart() throws SensorHubException
     {        
         TCPConfig config = this.config.protocol;
-        
-        try
-        {
-            InetAddress addr = InetAddress.getByName(config.remoteHost);
-            
-            if (config.enableTLS)
-            {
-                SSLSocketFactory factory = (SSLSocketFactory)SSLSocketFactory.getDefault();
-                socket = factory.createSocket(addr, config.remotePort);
-                ((SSLSocket)socket).startHandshake();
-                is = socket.getInputStream();
-                os = socket.getOutputStream();
+
+        int count = 0;
+        int retryAttempts = this.config.connection.reconnectAttempts;
+        while(true) {
+            try {
+                InetAddress addr = InetAddress.getByName(config.remoteHost);
+
+                if (config.enableTLS) {
+                    SSLSocketFactory factory = (SSLSocketFactory) SSLSocketFactory.getDefault();
+                    socket = factory.createSocket(addr, config.remotePort);
+                    ((SSLSocket) socket).startHandshake();
+                    is = socket.getInputStream();
+                    os = socket.getOutputStream();
+                } else {
+                    SocketAddress endpoint = new InetSocketAddress(addr, config.remotePort);
+                    socket = new Socket();
+                    socket.connect(endpoint, this.config.connection.connectTimeout);
+                    is = socket.getInputStream();
+                    os = socket.getOutputStream();
+                    break;
+                }
+            } catch (IOException e) {
+                if(++count >= retryAttempts)
+                    throw new SensorHubException("Cannot connect to remote host "
+                        + config.remoteHost + ":" + config.remotePort + " via TCP", e);
             }
-            else
-            {
-                SocketAddress endpoint = new InetSocketAddress(addr, config.remotePort);
-                socket = new Socket();
-                socket.connect(endpoint, 1000);
-                is = socket.getInputStream();
-                os = socket.getOutputStream();
-            }
-        }
-        catch (IOException e)
-        {
-            throw new SensorHubException("Cannot connect to remote host "
-                                         + config.remoteHost + ":" + config.remotePort + " via TCP", e);
         }
     }
 

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/comm/TCPCommProvider.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/comm/TCPCommProvider.java
@@ -73,7 +73,8 @@ public class TCPCommProvider extends AbstractModule<TCPCommProviderConfig> imple
 
         int count = 0;
         int retryAttempts = this.config.connection.reconnectAttempts;
-        while(true) {
+        boolean isRetrying = retryAttempts >= 0;
+        while(isRetrying) {
             try {
                 InetAddress addr = InetAddress.getByName(config.remoteHost);
 
@@ -89,6 +90,7 @@ public class TCPCommProvider extends AbstractModule<TCPCommProviderConfig> imple
                     socket.connect(endpoint, this.config.connection.connectTimeout);
                     is = socket.getInputStream();
                     os = socket.getOutputStream();
+                    isRetrying = false;
                     break;
                 }
             } catch (IOException e) {

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/comm/TCPCommProvider.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/comm/TCPCommProvider.java
@@ -73,8 +73,8 @@ public class TCPCommProvider extends AbstractModule<TCPCommProviderConfig> imple
 
         int count = 0;
         int retryAttempts = this.config.connection.reconnectAttempts;
-        boolean isRetrying = retryAttempts >= 0;
-        while(isRetrying) {
+//        boolean isRetrying = retryAttempts >= 0;
+        while(true) {
             try {
                 InetAddress addr = InetAddress.getByName(config.remoteHost);
 
@@ -90,7 +90,7 @@ public class TCPCommProvider extends AbstractModule<TCPCommProviderConfig> imple
                     socket.connect(endpoint, this.config.connection.connectTimeout);
                     is = socket.getInputStream();
                     os = socket.getOutputStream();
-                    isRetrying = false;
+//                    isRetrying = false;
                     break;
                 }
             } catch (IOException e) {


### PR DESCRIPTION
This change updates the TCPCommProvider to use configuration options from TCPConfig to make retry attempts and uses the connection timeout from the config instead of the 1 second default.