### PR TITLE
Unregister systems from system state database recursively

### DIFF
--- a/sensorhub-core/src/main/java/org/sensorhub/impl/system/DefaultSystemRegistry.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/system/DefaultSystemRegistry.java
@@ -291,7 +291,7 @@ public class DefaultSystemRegistry implements ISystemDriverRegistry
 
             systemStateDb.getDataStreamStore().removeEntries(dsFilter);
             systemStateDb.getCommandStreamStore().removeEntries(csFilter);
-            var count = systemStateDb.getSystemDescStore().removeEntries(topLevelSystemsFilter);
+            var count = systemStateDb.getSystemDescStore().removeEntries(procFilter);
 
             if (count > 0)
                 log.info("Database #{} now handles system {}. Removing all records from state DB", db.getDatabaseNum(), uid);


### PR DESCRIPTION
This is a small change that I overlooked previously. Only top level systems should be re-registered as they will register their submodules, but the `removeEntries()` method will not unregister recursively, so revert to using the `procFilter` which includes members of systems in the SystemFilter.