### PR TITLE
[Core] Parse geometry from DataComponent for systems

### DIFF
--- a/lib-ogc/sensorml-core/src/main/java/org/vast/sensorML/PhysicalSystemImpl.java
+++ b/lib-ogc/sensorml-core/src/main/java/org/vast/sensorML/PhysicalSystemImpl.java
@@ -293,7 +293,7 @@ public class PhysicalSystemImpl extends AggregateProcessImpl implements Physical
             else if (pos instanceof Pose pose)
                 return pose.toLocation();
             else if (pos instanceof DataComponent component) {
-                var geometry = parseGeometry(component);
+                var geometry = convertToGeometry(component);
                 if (geometry != null)
                     return geometry;
             }
@@ -312,23 +312,23 @@ public class PhysicalSystemImpl extends AggregateProcessImpl implements Physical
 
 
     /**
-     * Helper method to parse the geometry from a DataComponent
+     * Helper method to convert a DataComponent's location to a geometry
      *
      * @param dataComponent the DataComponent to extract the geometry from
      * @return the AbstractGeometry if found, null otherwise
      */
-    private AbstractGeometry parseGeometry(DataComponent dataComponent)
+    private AbstractGeometry convertToGeometry(DataComponent dataComponent)
     {
         // The DataComponent is itself a Vector
         if (dataComponent instanceof Vector vector) {
-            return parseGeometry(vector);
+            return convertToGeometry(vector);
         }
 
         // Find the sensor location field in the DataRecord and get the Vector from it
         for (int i = 0; i < dataComponent.getComponentCount(); i++) {
             DataComponent component = dataComponent.getComponent(i);
             if (component instanceof Vector vector && Objects.equals(vector.getDefinition(), SWEConstants.DEF_SENSOR_LOC)) {
-                return parseGeometry(vector);
+                return convertToGeometry(vector);
             }
         }
 
@@ -337,12 +337,12 @@ public class PhysicalSystemImpl extends AggregateProcessImpl implements Physical
 
 
     /**
-     * Helper method to parse the geometry from a Vector
+     * Helper method to convert a Vector to a geometry
      *
      * @param vector the Vector to extract the geometry from
      * @return the AbstractGeometry if found, null otherwise
      */
-    private AbstractGeometry parseGeometry(Vector vector)
+    private AbstractGeometry convertToGeometry(Vector vector)
     {
         double[] coordinates = new double[vector.getNumCoordinates()];
         for (int i = 0; i < vector.getNumCoordinates(); i++) {

--- a/lib-ogc/sensorml-core/src/main/java/org/vast/sensorML/PhysicalSystemImpl.java
+++ b/lib-ogc/sensorml-core/src/main/java/org/vast/sensorML/PhysicalSystemImpl.java
@@ -17,8 +17,12 @@ package org.vast.sensorML;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import javax.xml.namespace.QName;
+
+import net.opengis.gml.v32.impl.GMLFactory;
 import org.vast.ogc.geopose.Pose;
+import org.vast.swe.SWEConstants;
 import org.vast.util.Asserts;
 import net.opengis.OgcPropertyList;
 import net.opengis.gml.v32.AbstractGeometry;
@@ -29,6 +33,7 @@ import net.opengis.sensorml.v20.PhysicalSystem;
 import net.opengis.sensorml.v20.SpatialFrame;
 import net.opengis.sensorml.v20.TemporalFrame;
 import net.opengis.swe.v20.DataArray;
+import net.opengis.swe.v20.DataComponent;
 import net.opengis.swe.v20.DataRecord;
 import net.opengis.swe.v20.Text;
 import net.opengis.swe.v20.Time;
@@ -274,16 +279,24 @@ public class PhysicalSystemImpl extends AggregateProcessImpl implements Physical
     }
 
 
+    /**
+     * Returns the geometry of the first position in the positionList
+     */
     @Override
     public AbstractGeometry getGeometry()
     {
         if (!positionList.isEmpty())
         {
             var pos = positionList.get(0);
-            if (pos instanceof AbstractGeometry)
-                return (AbstractGeometry)pos;
-            else if (pos instanceof Pose)
-                return ((Pose)pos).toLocation();
+            if (pos instanceof AbstractGeometry geometry)
+                return geometry;
+            else if (pos instanceof Pose pose)
+                return pose.toLocation();
+            else if (pos instanceof DataComponent component) {
+                var geometry = parseGeometry(component);
+                if (geometry != null)
+                    return geometry;
+            }
         }
         
         return super.getGeometry();
@@ -295,5 +308,54 @@ public class PhysicalSystemImpl extends AggregateProcessImpl implements Physical
     {
         Asserts.checkArgument(geom instanceof Point, "geom must be a Point");
         addPositionAsPoint((Point)geom);
+    }
+
+
+    /**
+     * Helper method to parse the geometry from a DataComponent
+     *
+     * @param dataComponent the DataComponent to extract the geometry from
+     * @return the AbstractGeometry if found, null otherwise
+     */
+    private AbstractGeometry parseGeometry(DataComponent dataComponent)
+    {
+        // The DataComponent is itself a Vector
+        if (dataComponent instanceof Vector vector) {
+            return parseGeometry(vector);
+        }
+
+        // Find the sensor location field in the DataRecord and get the Vector from it
+        for (int i = 0; i < dataComponent.getComponentCount(); i++) {
+            DataComponent component = dataComponent.getComponent(i);
+            if (component instanceof Vector vector && Objects.equals(vector.getDefinition(), SWEConstants.DEF_SENSOR_LOC)) {
+                return parseGeometry(vector);
+            }
+        }
+
+        return null;
+    }
+
+
+    /**
+     * Helper method to parse the geometry from a Vector
+     *
+     * @param vector the Vector to extract the geometry from
+     * @return the AbstractGeometry if found, null otherwise
+     */
+    private AbstractGeometry parseGeometry(Vector vector)
+    {
+        double[] coordinates = new double[vector.getNumCoordinates()];
+        for (int i = 0; i < vector.getNumCoordinates(); i++) {
+            coordinates[i] = vector.getComponent(i).getData().getDoubleValue();
+        }
+
+        Point point = new GMLFactory(true).newPoint();
+        if (vector.isSetReferenceFrame()) {
+            point.setSrsName(vector.getReferenceFrame());
+            point.setSrsDimension(vector.getNumCoordinates());
+        }
+        point.setPos(coordinates);
+
+        return point;
     }
 }


### PR DESCRIPTION
This change modifies getGeometry to return a point if the position is a Vector or DataComponent containing a location Vector. This will be the case when using the default position config for a sensor. With this, new systems will be created with their geometry property set, and so will show up on the map and can be queried against using ConnectSystems API, for example, searching systems within a bounding box.

The geometry is set as a Vector or DataComponent in AbstractSensorModule.updateSensorDescription
[AbstractSensorModule.java#L658](https://github.com/opensensorhub/osh-core/blob/master/sensorhub-core/src/main/java/org/sensorhub/impl/sensor/AbstractSensorModule.java#L658)
[AbstractSensorModule.java#L663](https://github.com/opensensorhub/osh-core/blob/master/sensorhub-core/src/main/java/org/sensorhub/impl/sensor/AbstractSensorModule.java#L663)

![image](https://github.com/user-attachments/assets/68f0f522-10ec-4dc2-a41e-1703b734f3f8)

![image](https://github.com/user-attachments/assets/7bc8b659-a8f8-4560-bcad-bad4258de57f)
