### PR TITLE
[UI] Include parent hub in Federated Database module to fix error in DatabaseStreamPanel

### DIFF
--- a/sensorhub-webui-core/src/main/java/org/sensorhub/ui/AdminUI.java
+++ b/sensorhub-webui-core/src/main/java/org/sensorhub/ui/AdminUI.java
@@ -546,7 +546,7 @@ public class AdminUI extends com.vaadin.ui.UI implements UIConstants
         
         // add federated database
         if (configType == DatabaseConfig.class)
-            moduleList.add(new FederatedDbModuleAdapter(getParentHub().getDatabaseRegistry().getFederatedDatabase()));
+            moduleList.add(new FederatedDbModuleAdapter(getParentHub().getDatabaseRegistry().getFederatedDatabase(), getParentHub()));
         
         // add selected modules to list
         for (IModule<?> module: moduleRegistry.getLoadedModules())

--- a/sensorhub-webui-core/src/main/java/org/sensorhub/ui/FederatedDbModuleAdapter.java
+++ b/sensorhub-webui-core/src/main/java/org/sensorhub/ui/FederatedDbModuleAdapter.java
@@ -35,11 +35,12 @@ import org.slf4j.Logger;
 public class FederatedDbModuleAdapter implements IObsSystemDatabaseModule<DatabaseConfig>
 {
     IObsSystemDatabase delegate;
+    ISensorHub hub;
     
-    
-    public FederatedDbModuleAdapter(IObsSystemDatabase db)
+    public FederatedDbModuleAdapter(IObsSystemDatabase db, ISensorHub hub)
     {
         this.delegate = db;
+        this.hub = hub;
     }
     
 
@@ -120,7 +121,7 @@ public class FederatedDbModuleAdapter implements IObsSystemDatabaseModule<Databa
     @Override
     public ISensorHub getParentHub()
     {
-        return null;
+        return hub;
     }
 
 


### PR DESCRIPTION
Previously, you would be unable to click on data streams in the federated db, as a request would be made to the datastream's database's parent hub, but the Federated Database Module returns `null` for `getParentHub()`. 