### PR TITLE
Added Authentication in initial SOS-T Client GetCapabilitiesRequest

### DIFF
--- a/sensorhub-service-swe/src/main/java/org/sensorhub/impl/client/sost/SOSTClient.java
+++ b/sensorhub-service-swe/src/main/java/org/sensorhub/impl/client/sost/SOSTClient.java
@@ -203,6 +203,7 @@ public class SOSTClient extends AbstractModule<SOSTClientConfig> implements ICli
                     request.setConnectTimeOut(connectConfig.connectTimeout);
                     request.setService(SOSUtils.SOS);
                     request.setGetServer(getSosEndpointUrl());
+                    setAuth();
                     caps = sosUtils.sendRequest(request, false);
                 }
                 catch (Exception e)

--- a/sensorhub-service-swe/src/main/java/org/sensorhub/impl/service/sos/SOSService.java
+++ b/sensorhub-service-swe/src/main/java/org/sensorhub/impl/service/sos/SOSService.java
@@ -53,7 +53,7 @@ public class SOSService extends SWEService<SOSServiceConfig>
         for (var formatConfig: config.customFormats)
         {
             if (Strings.isNullOrEmpty(formatConfig.mimeType))
-                throw new SensorHubException("Custum format must specify a mime type");
+                throw new SensorHubException("Custom format must specify a mime type");
         }        
         
         this.securityHandler = new SOSSecurity(this, config.security.enableAccessControl);


### PR DESCRIPTION
Before you would have to disable Access Control in order to receive requests to SOS Service, additionally you would have to disable "Basic" Authentication in the HttpServer Config. Also, fixed a spelling error. 