### PR TITLE
Update CSAPI Push Module and add client IdEncoder fallback

### DIFF
--- a/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/client/ConSysApiClient.java
+++ b/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/client/ConSysApiClient.java
@@ -256,7 +256,7 @@ public class ConSysApiClient
     
     public CompletableFuture<IProcedureWithDesc> getProcedureByUid(String uid, ResourceFormat format)
     {
-        return sendGetRequest(endpoint.resolve(PROCEDURES_COLLECTION + "?uid=" + uid), format, body -> {
+        return sendGetRequest(endpoint.resolve(PROCEDURES_COLLECTION + "?id=" + uid), format, body -> {
             try
             {
                 var ctx = new RequestContext(body);
@@ -369,7 +369,7 @@ public class ConSysApiClient
 
     public CompletableFuture<ISystemWithDesc> getSystemByUid(String uid, ResourceFormat format) throws ExecutionException, InterruptedException
     {
-        return sendGetRequest(endpoint.resolve(SYSTEMS_COLLECTION + "?uid=" + uid), format, body -> {
+        return sendGetRequest(endpoint.resolve(SYSTEMS_COLLECTION + "?id=" + uid), format, body -> {
             try
             {
                 var ctx = new RequestContext(body);
@@ -565,7 +565,7 @@ public class ConSysApiClient
 
     public CompletableFuture<IFeature> getSamplingFeatureByUID(String uid, ResourceFormat format)
     {
-        return sendGetRequest(endpoint.resolve(SF_COLLECTION + "?foi=" + uid), format, body -> {
+        return sendGetRequest(endpoint.resolve(SF_COLLECTION + "?id=" + uid), format, body -> {
             try
             {
                 var ctx = new RequestContext(body);

--- a/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/client/ConSysApiClient.java
+++ b/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/client/ConSysApiClient.java
@@ -563,7 +563,7 @@ public class ConSysApiClient
         });
     }
 
-    public CompletableFuture<IFeature> getSamplingFeatureByUID(String uid, ResourceFormat format)
+    public CompletableFuture<IFeature> getSamplingFeatureByUid(String uid, ResourceFormat format)
     {
         return sendGetRequest(endpoint.resolve(SF_COLLECTION + "?id=" + uid), format, body -> {
             try

--- a/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/client/ConSysApiClientModule.java
+++ b/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/client/ConSysApiClientModule.java
@@ -210,7 +210,7 @@ public class ConSysApiClientModule extends AbstractModule<ConSysApiClientConfig>
     private String tryUpdateSamplingFeature(IFeature feature)
     {
         try {
-            var oldSamplingFeature = client.getSamplingFeatureByUID(feature.getUniqueIdentifier(), ResourceFormat.JSON).get();
+            var oldSamplingFeature = client.getSamplingFeatureByUid(feature.getUniqueIdentifier(), ResourceFormat.JSON).get();
             String samplingFeatureId;
             if (oldSamplingFeature != null) {
                 samplingFeatureId = oldSamplingFeature.getId();

--- a/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/client/ConSysApiClientModule.java
+++ b/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/client/ConSysApiClientModule.java
@@ -21,6 +21,7 @@ import org.sensorhub.api.system.SystemRemovedEvent;
 import org.sensorhub.api.system.SystemDisabledEvent;
 import org.sensorhub.api.system.SystemEvent;
 import org.sensorhub.impl.module.AbstractModule;
+import org.sensorhub.impl.security.ClientAuth;
 import org.sensorhub.impl.service.consys.resource.ResourceFormat;
 import org.vast.ogc.gml.IFeature;
 import org.vast.ogc.om.SamplingFeature;
@@ -71,6 +72,13 @@ public class ConSysApiClientModule extends AbstractModule<ConSysApiClientConfig>
         this.dataStreams = new ConcurrentSkipListMap<>();
     }
 
+    private void setAuth()
+    {
+        ClientAuth.getInstance().setUser(config.conSys.user);
+        if (config.conSys.password != null)
+            ClientAuth.getInstance().setPassword(config.conSys.password.toCharArray());
+    }
+
     @Override
     public void setConfiguration(ConSysApiClientConfig config)
     {
@@ -106,14 +114,8 @@ public class ConSysApiClientModule extends AbstractModule<ConSysApiClientConfig>
         // Check if endpoint is available
         try{
             HttpURLConnection urlConnection = (HttpURLConnection) client.endpoint.toURL().openConnection();
-            if (!Strings.isNullOrEmpty(config.conSys.user)) {
-                urlConnection.setAuthenticator(new Authenticator() {
-                    @Override
-                    public PasswordAuthentication getPasswordAuthentication() {
-                        return new PasswordAuthentication(config.conSys.user, config.conSys.password != null ? config.conSys.password.toCharArray() : new char[0]);
-                    }
-                });
-            }
+            if (!Strings.isNullOrEmpty(config.conSys.user))
+                setAuth();
             urlConnection.connect();
             Asserts.checkArgument(urlConnection.getResponseCode() == HttpURLConnection.HTTP_OK);
         } catch (Exception e) {

--- a/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/client/ConSysApiClientModule.java
+++ b/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/client/ConSysApiClientModule.java
@@ -547,7 +547,7 @@ public class ConSysApiClientModule extends AbstractModule<ConSysApiClientConfig>
                 try {
                     startStream(registeredDataStream);
                 } catch (ClientException ex) {
-                    throw new RuntimeException(ex);
+                    getLogger().error(ex.getMessage());
                 }
             });
         }

--- a/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/feature/AbstractFeatureBindingGeoJson.java
+++ b/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/feature/AbstractFeatureBindingGeoJson.java
@@ -95,7 +95,7 @@ public abstract class AbstractFeatureBindingGeoJson<V extends IFeature, DB exten
     {
         try
         {
-            var f = getFeatureWithId(key, res);
+            var f = key != null ? getFeatureWithId(key, res) : res;
             this.showLinks = showLinks;
             geoJsonBindings.writeFeature(writer, f);
             writer.flush();

--- a/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/resource/ResourceBinding.java
+++ b/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/resource/ResourceBinding.java
@@ -17,6 +17,7 @@ package org.sensorhub.impl.service.consys.resource;
 import java.io.IOException;
 import java.util.Collection;
 import org.sensorhub.api.common.IdEncoders;
+import org.sensorhub.impl.common.IdEncodersBase32;
 import org.vast.util.Asserts;
 
 
@@ -43,7 +44,7 @@ public abstract class ResourceBinding<K, V>
     protected ResourceBinding(RequestContext ctx, IdEncoders idEncoders)
     {
         this.ctx = Asserts.checkNotNull(ctx, RequestContext.class);
-        this.idEncoders = idEncoders;
+        this.idEncoders = idEncoders != null ? idEncoders : new IdEncodersBase32();
     }
     
     


### PR DESCRIPTION
This fix adds support for `SamplingFeatures` in the CSAPI client that wasn't there previously. I had to make 1-line changes in [AbstractFeatureBindingGeoJson.java](https://github.com/opensensorhub/osh-core/compare/master...earocorn:clientside-consys-bindings?expand=1#diff-c8e66bc665ac30b8d17dd0d9977a4e78d26596ae7183844a053e2500a2f52b10) and [ResourceBinding.java](https://github.com/opensensorhub/osh-core/compare/master...earocorn:clientside-consys-bindings?expand=1#diff-e9235045339b26093f16a7f33b98514671b16c2ed6b5b6a76960874c446958ae) in order to support "keyless" `IFeature` serialization and clients without specified `IdEncoders` (using fallback to Base32 encoders as suggested).