### PR TITLE
Added version to the config panel

### DIFF
--- a/sensorhub-core/src/main/java/org/sensorhub/api/module/ModuleConfig.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/api/module/ModuleConfig.java
@@ -44,7 +44,9 @@ public class ModuleConfig extends ModuleConfigBase
     @DisplayInfo(label="Auto Start", desc="Set to automatically start the module when it is loaded")
     @SerializedName(value="autoStart", alternate={"enabled"})
     public boolean autoStart = false;
-    
+
+    @DisplayInfo(label="Version", desc="Version of the driver")
+    public String version;
     
     @Override
     public ModuleConfig clone()

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/module/ModuleRegistry.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/module/ModuleRegistry.java
@@ -488,6 +488,7 @@ public class ModuleRegistry implements IModuleManager<IModule<?>>, IEventListene
             {
                 ((ModuleConfig)config).id = UUID.randomUUID().toString();
                 ((ModuleConfig)config).name = "New " + provider.getModuleName();
+                ((ModuleConfig)config).version = provider.getModuleVersion();
                 ((ModuleConfig)config).autoStart = false;
             }
             

--- a/sensorhub-webui-core/src/main/java/org/sensorhub/ui/GenericConfigForm.java
+++ b/sensorhub-webui-core/src/main/java/org/sensorhub/ui/GenericConfigForm.java
@@ -298,7 +298,7 @@ public class GenericConfigForm extends VerticalLayout implements IModuleConfigFo
         
         // disable edit (read only)
         if (propId.equals(PROP_ID) ||
-            propId.endsWith(PROP_MODULECLASS))
+            propId.endsWith(PROP_MODULECLASS) || propId.equals(PROP_VERSION))
             field.setReadOnly(true);
         
         // show these only for top level modules

--- a/sensorhub-webui-core/src/main/java/org/sensorhub/ui/api/UIConstants.java
+++ b/sensorhub-webui-core/src/main/java/org/sensorhub/ui/api/UIConstants.java
@@ -54,5 +54,6 @@ public interface UIConstants
     public static final String PROP_NAME = "name";
     public static final String PROP_AUTOSTART = "autoStart";
     public static final String PROP_MODULECLASS = "moduleClass";
+    public static final String PROP_VERSION = "version";
     
 }


### PR DESCRIPTION
This PR updates the admin config panel to display the currently configured driver version. Previously, version information was only visible when adding a new module. With this change, the version is now shown in the driver's config panel, allowing admin to verify the version without going through the add-module flow. 