### PR TITLE
Allow configuration of multiple static file servers with optional authentication

### DIFF
--- a/sensorhub-core/src/main/java/org/sensorhub/impl/service/FileServerConfig.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/service/FileServerConfig.java
@@ -1,0 +1,39 @@
+/***************************** BEGIN LICENSE BLOCK ***************************
+
+ The contents of this file are subject to the Mozilla Public License, v. 2.0.
+ If a copy of the MPL was not distributed with this file, You can obtain one
+ at http://mozilla.org/MPL/2.0/.
+
+ Software distributed under the License is distributed on an "AS IS" basis,
+ WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ for the specific language governing rights and limitations under the License.
+
+ The Initial Developer is Botts Innovative Research Inc. Portions created by the Initial
+ Developer are Copyright (C) 2025 the Initial Developer. All Rights Reserved.
+
+ ******************************* END LICENSE BLOCK ***************************/
+
+package org.sensorhub.impl.service;
+
+import org.sensorhub.api.config.DisplayInfo;
+
+public class FileServerConfig {
+
+    @DisplayInfo(desc="Directory where static web content is located.")
+    public String staticContentRootUrl;
+
+    @DisplayInfo(desc="Root URL where static web content will be served.")
+    public String staticContentRootDir;
+
+    @DisplayInfo(label="Require Authentication", desc="Set to require remote users to be authentified before they can use this service")
+    public boolean requireAuth;
+
+    public FileServerConfig() {}
+
+    public FileServerConfig(String contentUrl, String contentDir, boolean requireAuth) {
+        this.requireAuth = requireAuth;
+        staticContentRootDir = contentDir;
+        staticContentRootUrl = contentUrl;
+    }
+
+}

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/service/HttpServerConfig.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/service/HttpServerConfig.java
@@ -18,6 +18,9 @@ import org.sensorhub.api.config.DisplayInfo;
 import org.sensorhub.api.config.DisplayInfo.FieldType.Type;
 import org.sensorhub.api.module.ModuleConfig;
 
+import java.util.ArrayList;
+import java.util.List;
+
 
 /**
  * <p>
@@ -42,14 +45,13 @@ public class HttpServerConfig extends ModuleConfig
     @DisplayInfo(label="HTTPS Port", desc="TCP port where server will listen for secure HTTP (HTTPS) connections (use 0 to disable HTTPS).")
     public int httpsPort = 0;
     
-    
-    @DisplayInfo(desc="Root URL where static web content will be served.")
-    public String staticDocsRootUrl = "/";
-    
-    
-    @DisplayInfo(desc="Directory where static web content is located.")
-    public String staticDocsRootDir = "web";
-    
+
+    @DisplayInfo(label = "Static File Servers", desc = "Static web content configurations")
+    public List<FileServerConfig> fileServerConfigs = new ArrayList<>(List.of(new FileServerConfig(
+                            "/",
+                            "web",
+                            false)));
+
     
     @DisplayInfo(desc="Root URL where the server will accept requests. This will be the prefix to all servlet URLs.")
     public String servletsRootUrl = "/sensorhub";

--- a/sensorhub-core/src/test/java/org/sensorhub/impl/service/TestHttpServer.java
+++ b/sensorhub-core/src/test/java/org/sensorhub/impl/service/TestHttpServer.java
@@ -19,8 +19,10 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.Authenticator;
+import java.net.HttpURLConnection;
 import java.net.PasswordAuthentication;
 import java.net.URL;
+import java.util.ArrayList;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -33,13 +35,17 @@ import org.sensorhub.impl.module.ModuleRegistry;
 import org.sensorhub.impl.security.BasicSecurityRealmConfig;
 import org.sensorhub.impl.security.BasicSecurityRealmConfig.UserConfig;
 import org.sensorhub.impl.service.HttpServerConfig.AuthMethod;
+import org.vast.util.Asserts;
 
 
 public class TestHttpServer
 {
-    private static String USER_ID = "admin";
-    private static String PASSWORD = "pwd";
-    
+    private static final String USER_ID = "admin";
+    private static final String PASSWORD = "pwd";
+    private static final String PRIVATE_PATH = "/testStaticPrivate";
+    private static final String PUBLIC_PATH = "/testStaticPublic";
+    private static final String TEST_FILE = "/test.txt";
+
     ModuleRegistry registry;
     
     
@@ -49,13 +55,29 @@ public class TestHttpServer
         System.out.println("\n*****************************");
         var hub = new SensorHub();
         hub.start();
-        registry = hub.getModuleRegistry(); 
+        registry = hub.getModuleRegistry();
+        Authenticator.setDefault(null);
     }
     
     
     private HttpServer startServer(AuthMethod authMethod) throws Exception
     {
         HttpServerConfig config = new HttpServerConfig();
+
+        var testPublicFilepath = TestHttpServer.class.getResource(PUBLIC_PATH).getFile();
+        var testPrivateFilepath = TestHttpServer.class.getResource(PRIVATE_PATH).getFile();
+
+        config.fileServerConfigs = new ArrayList<>();
+        config.fileServerConfigs.add(new FileServerConfig(
+                PUBLIC_PATH,
+                testPublicFilepath,
+                false
+        ));
+        config.fileServerConfigs.add(new FileServerConfig(
+                PRIVATE_PATH + "/*",
+                testPrivateFilepath,
+                true
+        ));
         config.autoStart = true;
         config.authMethod = authMethod;
         return (HttpServer)registry.loadModule(config);
@@ -72,7 +94,50 @@ public class TestHttpServer
         securityConfig.users.add(user);
         registry.loadModule(securityConfig);
     }
-    
+
+    private void testConnectStatus(AuthMethod authMethod, boolean isAuthenticated, String endpoint, int expectedValue) throws Exception {
+        addUsers();
+        var httpServer = startServer(authMethod);
+
+        // connect to servlet and check response
+        URL url = new URL(httpServer.getServerBaseUrl() + endpoint);
+        System.out.println(url);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+
+        if (authMethod != null && isAuthenticated)
+        {
+            conn.setAuthenticator(new Authenticator() {
+                @Override
+                protected PasswordAuthentication getPasswordAuthentication() {
+                    PasswordAuthentication pa = new PasswordAuthentication (USER_ID, PASSWORD.toCharArray());
+                    return pa;
+                }
+            });
+        }
+
+        conn.setRequestMethod("GET");
+        conn.setUseCaches(false);
+        conn.connect();
+
+//        System.out.println(conn.getResponseMessage());
+//        System.out.println(conn.getResponseCode());
+        Asserts.checkArgument(conn.getResponseCode() == expectedValue);
+    }
+
+    @Test
+    public void testConnectPublicContent() throws Exception {
+        testConnectStatus(AuthMethod.NONE, false, PUBLIC_PATH, 200);
+    }
+
+    @Test
+    public void testConnectPrivateContentWithAuth() throws Exception {
+        testConnectStatus(AuthMethod.BASIC, true, PRIVATE_PATH + TEST_FILE, 200);
+    }
+
+    @Test
+    public void testConnectPrivateContentNoAuth() throws Exception {
+        testConnectStatus(AuthMethod.BASIC, false, PRIVATE_PATH + TEST_FILE, 401);
+    }
     
     @Test
     public void testStartServer() throws Exception

--- a/sensorhub-core/src/test/resources/testStaticPrivate/test.txt
+++ b/sensorhub-core/src/test/resources/testStaticPrivate/test.txt
@@ -1,0 +1,1 @@
+im private

--- a/sensorhub-core/src/test/resources/testStaticPublic/test.txt
+++ b/sensorhub-core/src/test/resources/testStaticPublic/test.txt
@@ -1,0 +1,1 @@
+im public


### PR DESCRIPTION
This allows the configuration of multiple static file servers in the `HTTPServerConfig`. It also allows you to enable authentication on specified file servers.

This keeps the default file server the same ("/", "web")