### PR TITLE
Add simple "equals" value predicate for observation results

### DIFF
--- a/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/obs/DataStreamHandler.java
+++ b/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/obs/DataStreamHandler.java
@@ -141,6 +141,16 @@ public class DataStreamHandler extends ResourceHandler<DataStreamKey, IDataStrea
         {
             builder.withObservedProperties(obsProps);
         }
+
+        // system param
+        var sysIDs = parseResourceIdsOrUids("system", queryParams, idEncoders.getSystemIdEncoder());
+        if (sysIDs != null && !sysIDs.isEmpty())
+        {
+            if (sysIDs.isUids())
+                builder.withSystems().withUniqueIDs(sysIDs.getUids()).includeMembers(true).done();
+            else
+                builder.withSystems().withInternalIDs(sysIDs.getBigIds()).includeMembers(true).done();
+        }
     }
 
 

--- a/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/task/CommandStreamHandler.java
+++ b/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/task/CommandStreamHandler.java
@@ -126,6 +126,16 @@ public class CommandStreamHandler extends ResourceHandler<CommandStreamKey, ICom
                 .withInternalIDs(foiIDs)
                 .done();
         }*/
+
+        // system param
+        var sysIDs = parseResourceIdsOrUids("system", queryParams, idEncoders.getSystemIdEncoder());
+        if (sysIDs != null && !sysIDs.isEmpty())
+        {
+            if (sysIDs.isUids())
+                builder.withSystems().withUniqueIDs(sysIDs.getUids()).includeMembers(true).done();
+            else
+                builder.withSystems().withInternalIDs(sysIDs.getBigIds()).includeMembers(true).done();
+        }
     }
 
 


### PR DESCRIPTION
This adds a simple "equals" value filter in the connected systems API for filtering observations results by name. I would like to extend this in the future to fully support [CQL2 ](https://docs.ogc.org/is/21-065r2/21-065r2.html), but this simple filter is powerful enough for now.