### PR TITLE
Implement countMatchingEntries() in FederatedObsStore

### DIFF
--- a/sensorhub-core/src/main/java/org/sensorhub/impl/database/registry/FederatedObsStore.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/database/registry/FederatedObsStore.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.sensorhub.api.common.BigId;


### PR DESCRIPTION
Helps when underlying datastores have a more efficient implementation rather than counting stream from selectEntries(). 😆