### PR TITLE
Swe proxy enable complex array add

### DIFF
--- a/lib-ogc/swe-common-core/src/main/java/org/vast/data/DataBlockProxy.java
+++ b/lib-ogc/swe-common-core/src/main/java/org/vast/data/DataBlockProxy.java
@@ -191,7 +191,13 @@ public class DataBlockProxy implements IDataAccessor, InvocationHandler
             }
             
             // create new element data block
-            var newDblk = array.getElementType().createDataBlock();
+            DataBlock newDblk;
+            if(args == null || args.length == 0) {
+                newDblk = array.getElementType().createDataBlock();
+            } else {
+                assert args[0] instanceof IDataAccessor;
+                newDblk = ((IDataAccessor)args[0]).getDataBlock();
+            }
             arrayData.add(newDblk);
             ((DataArrayImpl)array).updateSizeComponent(array.getComponentCount()+1);
             var parent = ((AbstractDataComponentImpl)array.getParent());
@@ -206,8 +212,7 @@ public class DataBlockProxy implements IDataAccessor, InvocationHandler
                 accessor.wrap(newDblk);
                 return accessor;
             }
-            else
-            {
+            else if(!(args[0] instanceof IDataAccessor)){
                 var argType = method.getParameters()[0].getType();
                 var val = args[0];
                 setDataValue(newDblk, argType, val);

--- a/lib-ogc/swe-common-core/src/main/java/org/vast/data/DataBlockProxy.java
+++ b/lib-ogc/swe-common-core/src/main/java/org/vast/data/DataBlockProxy.java
@@ -191,9 +191,11 @@ public class DataBlockProxy implements IDataAccessor, InvocationHandler
             }
             
             // create new element data block
-            DataBlock newDblk = array.getElementType().createDataBlock();
+            DataBlock newDblk;
             if (args != null && args.length > 0 && args[0] instanceof IDataAccessor) {
                 newDblk = ((IDataAccessor)args[0]).getDataBlock();
+            } else {
+                newDblk = array.getElementType().createDataBlock();
             }
             arrayData.add(newDblk);
             ((DataArrayImpl)array).updateSizeComponent(array.getComponentCount()+1);

--- a/lib-ogc/swe-common-core/src/main/java/org/vast/data/DataBlockProxy.java
+++ b/lib-ogc/swe-common-core/src/main/java/org/vast/data/DataBlockProxy.java
@@ -191,11 +191,8 @@ public class DataBlockProxy implements IDataAccessor, InvocationHandler
             }
             
             // create new element data block
-            DataBlock newDblk;
-            if(args == null || args.length == 0) {
-                newDblk = array.getElementType().createDataBlock();
-            } else {
-                assert args[0] instanceof IDataAccessor;
+            DataBlock newDblk = array.getElementType().createDataBlock();
+            if (args != null && args.length > 0 && args[0] instanceof IDataAccessor) {
                 newDblk = ((IDataAccessor)args[0]).getDataBlock();
             }
             arrayData.add(newDblk);


### PR DESCRIPTION
Enables the ability to pass complex objects to any `add` functions under the IDataAccessor interface.

Should be of the format `void addComplexType(ComplexType val)`