### PR TITLE
Fixed JSON parsing of nested variable-sized arrays

### DIFF
--- a/lib-ogc/swe-common-core/src/main/java/org/vast/swe/fast/JsonDataParserGson.java
+++ b/lib-ogc/swe-common-core/src/main/java/org/vast/swe/fast/JsonDataParserGson.java
@@ -332,13 +332,14 @@ public class JsonDataParserGson extends AbstractDataParser
             
             // case of array with variable size items
             // e.g. item is itself a variable size array or a choice
-            if (varSizeArray != null && varSizeArray.getData() instanceof DataBlockList)
+            if (varSizeArray != null && varSizeArray.hasData() && varSizeArray.getData() instanceof DataBlockList)
             {
                 var arrayData = (DataBlockList)varSizeArray.getData();
                 var globalIdx = index;
                 for (int i = 0; i < arraySize; i++)
                 {
                     var itemData = arrayData.get(i);
+                    varSizeArray.getElementType().setData(itemData);
                     globalIdx += eltProcessor.process(itemData, 0);
                 }
                 index = globalIdx;

--- a/lib-ogc/swe-common-core/src/test/java/org/vast/swe/fast/TestJsonDataParser.java
+++ b/lib-ogc/swe-common-core/src/test/java/org/vast/swe/fast/TestJsonDataParser.java
@@ -22,6 +22,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
+import org.vast.swe.SWEConstants;
 import org.vast.swe.SWEHelper;
 import com.google.common.collect.Lists;
 import net.opengis.swe.v20.Count;
@@ -230,6 +231,42 @@ public class TestJsonDataParser
         }
         
         writeReadAndCompare(dataStruct, records);
+    }
+
+    @Test
+    public void testWriteAndReadBackNestedVarSizeArray() throws IOException
+    {
+        // create record structure
+        SWEHelper fac = new SWEHelper();
+        Count sizeField;
+        Count subArraySizeField;
+        DataRecord dataStruct = fac.createRecord()
+                .addSamplingTimeIsoUTC("t0")
+                .addField("size", sizeField = fac.createCount()
+                        .id("NUM_POINTS")
+                        .build())
+                .addField("array", fac.createArray()
+                        .withSizeComponent(sizeField)
+                .withElement("arrayRecord", fac.createRecord()
+                        .addField("subArrayCount", subArraySizeField = fac.createCount()
+                                .id("NUM_SUB_POINTS")
+                                .build())
+                        .addField("subArray", fac.createArray()
+                                .withSizeComponent(subArraySizeField)
+                                .withElement("subArrayValue", fac.createCount().build()))
+                        .build())
+                    .build())
+                .build();
+
+        String json = "{ \"size\": 1, \"array\": [\n{\n\"subArrayCount\": 2,\n\"subArray\": [ 1, 2 ]\n}\n]}";
+
+        JsonDataParserGson parser = new JsonDataParserGson();
+        parser.setInput(new ByteArrayInputStream(json.getBytes()));
+        parser.setDataComponents(dataStruct);
+        parser.setDataComponentFilter(comp -> !(comp.getDefinition() != null && comp.getDefinition().equals(SWEConstants.DEF_SAMPLING_TIME)));
+        parser.parseNextBlock();
+
+        System.out.println("Successfully parsed nested variable-sized array");
     }
 
 }

--- a/lib-ogc/swe-common-core/src/test/java/org/vast/swe/fast/TestJsonDataParser.java
+++ b/lib-ogc/swe-common-core/src/test/java/org/vast/swe/fast/TestJsonDataParser.java
@@ -234,7 +234,7 @@ public class TestJsonDataParser
     }
 
     @Test
-    public void testWriteAndReadBackNestedVarSizeArray() throws IOException
+    public void testReadNestedVarSizeArray() throws IOException
     {
         // create record structure
         SWEHelper fac = new SWEHelper();


### PR DESCRIPTION
This change adds a check and `DataComponent` update that is necessary for `JsonDataParserGson` to read `DataBlock`s that contain nested variable-sized arrays.

To test this change, you can remove the changes in `JsonDataParserGson`, run the unit test, and watch it fail at parsing a simple JSON data block.