### PR TITLE
Update SensorHubOsgi.java

### DIFF
--- a/sensorhub-core-osgi/src/main/java/org/sensorhub/impl/osgi/SensorHubOsgi.java
+++ b/sensorhub-core-osgi/src/main/java/org/sensorhub/impl/osgi/SensorHubOsgi.java
@@ -129,7 +129,9 @@ public class SensorHubOsgi
         for (var f: bundleJarFiles) {
             LOGGER.info("Installing bundle " + f);
             var bundle = systemCtx.installBundle(REF_PREFIX + f.toPath().toString());
-            bundle.start();
+            if (bundle.getHeaders().get("Fragment-Host") == null) {
+                bundle.start();
+            }
         }
         
         // start all installed bundles
@@ -144,7 +146,9 @@ public class SensorHubOsgi
                 try
                 {
                     var bundle = systemCtx.installBundle(REF_PREFIX + path.toString());
-                    bundle.start();
+                    if (bundle.getHeaders().get("Fragment-Host") == null) {
+                        bundle.start();
+                    }
                 }
                 catch (BundleException e)
                 {


### PR DESCRIPTION
Currently all bundles are being registered and started. We need to allow fragment bundles to be registered but this type of bundle does not require activation as it contributes functionality to a host bundle

This is an example of an osgi closure in a module that contributes custom forms to sensorhub-web-ui-core

```
osgi {
    manifest {
        attributes('Bundle-Vendor': 'Botts Innovative Research, Inc.')
        attributes('Bundle-SymbolicName': 'com.botts.ui.datafeed')
        attributes('Bundle-Version': version)

        // THIS is the important part:
        attributes('Fragment-Host': 'org.sensorhub.sensorhub-webui-core')

        attributes('-dsannotations': 'false')
        attributes('Export-Package': '')
        attributes('Import-Package': '*;resolution:=optional')
    }
}

```
In order to satisfy this SensorHubOSGi needs to skip attempting to start bundles that have the Fragment-Host attribute