### PR TITLE
check if the system is being replaced before throwing an error

### DIFF
--- a/sensorhub-core/src/main/java/org/sensorhub/impl/datastore/mem/InMemoryCommandStreamStore.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/datastore/mem/InMemoryCommandStreamStore.java
@@ -273,8 +273,13 @@ public class InMemoryCommandStreamStore implements ICommandStreamStore
                 var newValidTime = csInfo.getValidTime().begin();
                 
                 // error if command stream with same system/name/validTime already exists
+                // unless updating the same key
                 if (prevValidTime.equals(newValidTime))
+                {
+                    if (replace && key.equals(csKey))
+                        return map.put(csKey, csInfo);
                     throw new DataStoreException(DataStoreUtils.ERROR_EXISTING_COMMANDSTREAM);
+                }
                 
                 // don't add if previous entry had a more recent valid time
                 // or if new entry is dated in the future

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/datastore/mem/InMemoryDataStreamStore.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/datastore/mem/InMemoryDataStreamStore.java
@@ -224,8 +224,13 @@ public class InMemoryDataStreamStore
                 var newValidTime = dsInfo.getValidTime().begin();
                 
                 // error if datastream with same system/name/validTime already exists
+                // unless updating the same key
                 if (prevValidTime.equals(newValidTime))
+                {
+                    if (replace && key.equals(dsKey))
+                        return map.put(dsKey, dsInfo);
                     throw new DataStoreException(DataStoreUtils.ERROR_EXISTING_DATASTREAM);
+                }
                 
                 // don't add if previous entry had a more recent valid time
                 // or if new entry is dated in the future


### PR DESCRIPTION
When renaming a system, the module restarts and reregisters its datastreams/controlstreams. The `InMemoryDataStreamStore.put()` and the `InMemoryCommandStream.put()` calls a duplicate error even when updating the same key. This fix checks if the replace & key match before throwing the error.