### PR TITLE
Fix infinite loop in tcp comm provider

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.compile.nullAnalysis.mode": "automatic"
-}

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/comm/TCPCommProvider.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/comm/TCPCommProvider.java
@@ -82,17 +82,15 @@ public class TCPCommProvider extends AbstractModule<TCPCommProviderConfig> imple
                     SSLSocketFactory factory = (SSLSocketFactory) SSLSocketFactory.getDefault();
                     socket = factory.createSocket(addr, config.remotePort);
                     ((SSLSocket) socket).startHandshake();
-                    is = socket.getInputStream();
-                    os = socket.getOutputStream();
                 } else {
                     SocketAddress endpoint = new InetSocketAddress(addr, config.remotePort);
                     socket = new Socket();
                     socket.connect(endpoint, this.config.connection.connectTimeout);
-                    is = socket.getInputStream();
-                    os = socket.getOutputStream();
-//                    isRetrying = false;
-                    break;
                 }
+
+                is = socket.getInputStream();
+                os = socket.getOutputStream();
+                break;
             } catch (IOException e) {
                 if(++count >= retryAttempts)
                     throw new SensorHubException("Cannot connect to remote host "

--- a/sensorhub-core/src/main/java/org/sensorhub/impl/comm/TCPCommProvider.java
+++ b/sensorhub-core/src/main/java/org/sensorhub/impl/comm/TCPCommProvider.java
@@ -73,7 +73,7 @@ public class TCPCommProvider extends AbstractModule<TCPCommProviderConfig> imple
 
         int count = 0;
         int retryAttempts = this.config.connection.reconnectAttempts;
-//        boolean isRetrying = retryAttempts >= 0;
+        
         while(true) {
             try {
                 InetAddress addr = InetAddress.getByName(config.remoteHost);


### PR DESCRIPTION
Found an infinite loop when connecting via the TCP Comm Provider with TLS enabled. I added a break statement to resolve the issue.

Test:
- Start a TCP Comm Provider with TLS disabled and verify that it connects
- Start a TCP Comm Provider with TLS enabled and verify that it connects

I tested this via the tak driver connecting to a tak server with tls enabled and disabled and verified both work