### PR TITLE
Feat/consys custom formats

### DIFF
--- a/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/ConSysApiService.java
+++ b/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/ConSysApiService.java
@@ -278,7 +278,7 @@ public class ConSysApiService extends AbstractHttpServiceModule<ConSysApiService
         //foiHandler.addSubResource(obsStatsHandler);
         
         // command streams
-        var cmdStreamHandler = new CommandStreamHandler(handlerCtx, security.commandstream_permissions);
+        var cmdStreamHandler = new CommandStreamHandler(handlerCtx, security.commandstream_permissions, customFormats);
         rootHandler.addSubResource(cmdStreamHandler);
         systemsHandler.addSubResource(cmdStreamHandler);
         sysMembersHandler.addSubResource(cmdStreamHandler);

--- a/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/ConSysApiService.java
+++ b/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/ConSysApiService.java
@@ -262,7 +262,7 @@ public class ConSysApiService extends AbstractHttpServiceModule<ConSysApiService
         rootHandler.addSubResource(dataStreamHandler);
         systemsHandler.addSubResource(dataStreamHandler);
         sysMembersHandler.addSubResource(dataStreamHandler);
-        var dataSchemaHandler = new DataStreamSchemaHandler(handlerCtx, security.datastream_permissions);
+        var dataSchemaHandler = new DataStreamSchemaHandler(handlerCtx, security.datastream_permissions, customFormats);
         dataStreamHandler.addSubResource(dataSchemaHandler);
         
         // observations
@@ -282,11 +282,11 @@ public class ConSysApiService extends AbstractHttpServiceModule<ConSysApiService
         rootHandler.addSubResource(cmdStreamHandler);
         systemsHandler.addSubResource(cmdStreamHandler);
         sysMembersHandler.addSubResource(cmdStreamHandler);
-        var cmdSchemaHandler = new CommandStreamSchemaHandler(handlerCtx, security.commandstream_permissions);
+        var cmdSchemaHandler = new CommandStreamSchemaHandler(handlerCtx, security.commandstream_permissions, customFormats);
         cmdStreamHandler.addSubResource(cmdSchemaHandler);
-        
+
         // commands
-        var cmdHandler = new CommandHandler(handlerCtx, threadPool, security.command_permissions);
+        var cmdHandler = new CommandHandler(handlerCtx, threadPool, security.command_permissions, customFormats);
         cmdStreamHandler.addSubResource(cmdHandler);
         
         // command status

--- a/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/obs/CustomObsFormat.java
+++ b/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/obs/CustomObsFormat.java
@@ -15,10 +15,13 @@ Copyright (C) 2022 Sensia Software LLC. All Rights Reserved.
 package org.sensorhub.impl.service.consys.obs;
 
 import java.io.IOException;
+import org.sensorhub.api.command.ICommandData;
+import org.sensorhub.api.command.ICommandStreamInfo;
 import org.sensorhub.api.common.BigId;
 import org.sensorhub.api.common.IdEncoders;
 import org.sensorhub.api.data.IDataStreamInfo;
 import org.sensorhub.api.data.IObsData;
+import org.sensorhub.api.datastore.command.CommandStreamKey;
 import org.sensorhub.api.datastore.obs.DataStreamKey;
 import org.sensorhub.impl.service.consys.resource.RequestContext;
 import org.sensorhub.impl.service.consys.resource.ResourceBinding;
@@ -26,11 +29,54 @@ import org.sensorhub.impl.service.consys.resource.ResourceBinding;
 
 public interface CustomObsFormat
 {
+    /**
+     * @return true if this format can encode observations of the given
+     * datastream. Drives the "formats" list advertised on the datastream
+     * resource and explicit format selection.
+     */
     boolean isCompatible(IDataStreamInfo dsInfo);
-    
-    
+
+
+    /**
+     * @return true if this format should be auto-selected for browser requests
+     * with no explicit format (e.g. video formats playable in a browser).
+     * Defaults to {@link #isCompatible}; override to return false for formats
+     * that should be advertised but only served when explicitly requested.
+     */
+    default boolean isAutoSelectable(IDataStreamInfo dsInfo)
+    {
+        return isCompatible(dsInfo);
+    }
+
+
     ResourceBinding<DataStreamKey, IDataStreamInfo> getSchemaBinding(RequestContext ctx, IdEncoders idEncoders, IDataStreamInfo dsInfo) throws IOException;
-    
-    
+
+
     ResourceBinding<BigId, IObsData> getObsBinding(RequestContext ctx, IdEncoders idEncoders, IDataStreamInfo dsInfo) throws IOException;
+
+
+    /**
+     * @return a binding serving this format's view of a command stream's
+     * parameter schema, or null if this format does not support commands.
+     * Consulted by CommandStreamSchemaHandler when the commandFormat query
+     * param matches this format's mime type.
+     */
+    default ResourceBinding<CommandStreamKey, ICommandStreamInfo> getCommandSchemaBinding(RequestContext ctx, IdEncoders idEncoders, ICommandStreamInfo csInfo) throws IOException
+    {
+        return null;
+    }
+
+
+    /**
+     * @param forReading true when the binding will deserialize commands from
+     *        the request body (POST/publish ingestion), false when it will
+     *        serialize commands to the response (GET/stream)
+     * @return a binding encoding/decoding commands in this format, or null if
+     * this format does not support commands. Consulted by CommandHandler for
+     * both reads (GET/stream) and ingestion (POST with this content type).
+     */
+    default ResourceBinding<BigId, ICommandData> getCommandBinding(RequestContext ctx, IdEncoders idEncoders, ICommandStreamInfo csInfo, boolean forReading) throws IOException
+    {
+        return null;
+    }
 }

--- a/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/obs/DataStreamBindingJson.java
+++ b/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/obs/DataStreamBindingJson.java
@@ -151,6 +151,15 @@ public class DataStreamBindingJson extends ResourceBindingJson<DataStreamKey, ID
                     ResourceBindingJson<DataStreamKey, IDataStreamInfo> schemaBinding = null;
                     if (ResourceFormat.OM_JSON.getMimeType().equals(obsFormat))
                         schemaBinding = new DataStreamSchemaBindingOmJson(ctx, idEncoders, reader);
+                    // custom obs formats (e.g. application/swe+proto) bring their own
+                    // schema binding — checked BEFORE the SWE_FORMAT_PREFIX branch since
+                    // swe+proto also matches that prefix (mirrors DataStreamSchemaHandler.getBinding)
+                    else if (customFormats.containsKey(obsFormat))
+                    {
+                        var custom = customFormats.get(obsFormat).getSchemaBinding(ctx, idEncoders, null);
+                        if (custom instanceof ResourceBindingJson)
+                            schemaBinding = (ResourceBindingJson<DataStreamKey, IDataStreamInfo>) custom;
+                    }
                     else if (obsFormat.startsWith(ResourceFormat.SWE_FORMAT_PREFIX))
                         schemaBinding = new DataStreamSchemaBindingSweCommon(ResourceFormat.fromMimeType(obsFormat), ctx, idEncoders, reader);
                     if (schemaBinding == null)

--- a/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/obs/DataStreamSchemaHandler.java
+++ b/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/obs/DataStreamSchemaHandler.java
@@ -36,11 +36,20 @@ import org.vast.util.Asserts;
 public class DataStreamSchemaHandler extends ResourceHandler<DataStreamKey, IDataStreamInfo, DataStreamFilter, DataStreamFilter.Builder, IDataStreamStore>
 {
     public static final String[] NAMES = { "schema" };
-    
-    
+
+    final Map<String, CustomObsFormat> customFormats;
+
+
     public DataStreamSchemaHandler(HandlerContext ctx, ResourcePermissions permissions)
     {
+        this(ctx, permissions, java.util.Collections.emptyMap());
+    }
+
+
+    public DataStreamSchemaHandler(HandlerContext ctx, ResourcePermissions permissions, Map<String, CustomObsFormat> customFormats)
+    {
         super(ctx.getReadDb().getDataStreamStore(), ctx.getDataStreamIdEncoder(), ctx, permissions);
+        this.customFormats = customFormats != null ? customFormats : java.util.Collections.emptyMap();
     }
     
     
@@ -62,6 +71,16 @@ public class DataStreamSchemaHandler extends ResourceHandler<DataStreamKey, IDat
             return new DataStreamBindingHtml(ctx, idEncoders, obsFormat);
         else if (obsFormat.isOneOf(ResourceFormat.JSON, ResourceFormat.OM_JSON))
             return new DataStreamSchemaBindingOmJson(ctx, idEncoders, forReading);
+        // custom obs formats (e.g. application/swe+proto) provide their own schema
+        // binding — checked before the SWE_FORMAT_PREFIX branch since swe+proto
+        // also starts with "application/swe+"
+        else if (customFormats.containsKey(obsFormat.getMimeType()))
+        {
+            var dsInfo = dataStore.get(new DataStreamKey(ctx.getParentRef().internalID));
+            if (dsInfo == null)
+                throw ServiceErrors.notFound();
+            return customFormats.get(obsFormat.getMimeType()).getSchemaBinding(ctx, idEncoders, dsInfo);
+        }
         else if (obsFormat.getMimeType().startsWith(ResourceFormat.SWE_FORMAT_PREFIX))
             return new DataStreamSchemaBindingSweCommon(obsFormat, ctx, idEncoders, forReading);
         else

--- a/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/obs/ObsHandler.java
+++ b/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/obs/ObsHandler.java
@@ -169,7 +169,7 @@ public class ObsHandler extends BaseResourceHandler<BigId, IObsData, ObsFilter, 
                 var mimeType = entry.getKey();
                 var formatImpl = entry.getValue();
                 
-                if (formatImpl.isCompatible(dsInfo))
+                if (formatImpl.isAutoSelectable(dsInfo))
                 {
                     obsFormat = formatImpl;
                     ctx.getLogger().info("Auto-selecting format {}", mimeType);
@@ -230,9 +230,13 @@ public class ObsHandler extends BaseResourceHandler<BigId, IObsData, ObsFilter, 
         
         var queryParams = ctx.getParameterMap();
         var filter = getFilter(ctx.getParentRef(), queryParams, 0, Long.MAX_VALUE);
-        var responseFormat = parseFormat(queryParams);
+        // default to the format already set by the transport layer, if any
+        // (e.g. MQTT ":data/<format-token>" subtopics); an explicit f= query
+        // param still takes precedence
+        var defaultFormat = ctx.getFormat() != null ? ctx.getFormat() : ResourceFormat.AUTO;
+        var responseFormat = parseFormat(queryParams, defaultFormat);
         ctx.setFormatOptions(responseFormat, parseSelectArg(queryParams));
-        
+
         // detect if real-time request
         boolean isRealTime = (filter.getPhenomenonTime() == null && filter.getResultTime() == null) ||
                              (filter.getResultTime() != null && filter.getResultTime().beginsNow()) ||

--- a/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/resource/RequestContext.java
+++ b/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/resource/RequestContext.java
@@ -172,6 +172,25 @@ public class RequestContext
     
     
     /*
+     * Constructor for other protocols providing their own path/params and output stream,
+     * for one-shot (non-streaming) GET responses (e.g. NATS request-reply read)
+     */
+    public RequestContext(RestApiServlet servlet, URI resourceURI, OutputStream os)
+    {
+        this.clientSide = false;
+        this.servlet = Asserts.checkNotNull(servlet, Servlet.class);
+        this.req = null;
+        this.resp = null;
+        this.requestPathInfo = null;
+        this.streamHandler = null;
+        this.inputStream = null;
+        this.outputStream = Asserts.checkNotNull(os, OutputStream.class);
+        this.path = splitPath(resourceURI.getPath());
+        this.queryParams = parseQueryParams(resourceURI.getQuery());
+    }
+
+
+    /*
      * Constructor for other protocols providing their own path/params and stream handler (e.g. MQTT subscribe)
      */
     public RequestContext(RestApiServlet servlet, URI resourceURI, StreamHandler streamHandler)

--- a/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/task/CommandHandler.java
+++ b/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/task/CommandHandler.java
@@ -46,6 +46,7 @@ import org.sensorhub.impl.service.consys.InvalidRequestException.ErrorCode;
 import org.sensorhub.impl.service.consys.HandlerContext;
 import org.sensorhub.impl.service.consys.ServiceErrors;
 import org.sensorhub.impl.service.consys.RestApiServlet.ResourcePermissions;
+import org.sensorhub.impl.service.consys.obs.CustomObsFormat;
 import org.sensorhub.impl.service.consys.resource.BaseResourceHandler;
 import org.sensorhub.impl.service.consys.resource.IResourceHandler;
 import org.sensorhub.impl.service.consys.resource.RequestContext;
@@ -68,9 +69,10 @@ public class CommandHandler extends BaseResourceHandler<BigId, ICommandData, Com
     final SystemDatabaseTransactionHandler readOnlyTxHandler;
     final SystemDatabaseTransactionHandler fullTxHandler;
     final ScheduledExecutorService threadPool;
+    final Map<String, CustomObsFormat> customFormats;
     final Random random = new SecureRandom();
-    
-    
+
+
     public static class CommandHandlerContextData
     {
         public BigId streamID;
@@ -78,16 +80,23 @@ public class CommandHandler extends BaseResourceHandler<BigId, ICommandData, Com
         public BigId foiId;
         public CommandStreamTransactionHandler dsHandler;
     }
-    
-    
+
+
     public CommandHandler(HandlerContext ctx, ScheduledExecutorService threadPool, ResourcePermissions permissions)
     {
+        this(ctx, threadPool, permissions, java.util.Collections.emptyMap());
+    }
+
+
+    public CommandHandler(HandlerContext ctx, ScheduledExecutorService threadPool, ResourcePermissions permissions, Map<String, CustomObsFormat> customFormats)
+    {
         super(ctx.getReadDb().getCommandStore(), ctx.getCommandIdEncoder(), ctx, permissions);
-        
+
         this.eventBus = ctx.getEventBus();
         this.db = ctx.getReadDb();
         this.threadPool = threadPool;
-        
+        this.customFormats = customFormats != null ? customFormats : java.util.Collections.emptyMap();
+
         // I know the doc says otherwise but we need to use the federated DB for command transactions here
         // because we don't write to DB directly but rather send commands to systems that can be in other databases
         this.readOnlyTxHandler = new SystemDatabaseTransactionHandler(eventBus, ctx.getReadDb());
@@ -151,6 +160,15 @@ public class CommandHandler extends BaseResourceHandler<BigId, ICommandData, Com
         }
         
         // select binding depending on format
+        // custom formats (e.g. application/swe+proto) take precedence when the
+        // requested mime type matches and the format supports commands
+        if (contextData.csInfo != null && customFormats.containsKey(format.getMimeType()))
+        {
+            var binding = customFormats.get(format.getMimeType()).getCommandBinding(ctx, idEncoders, contextData.csInfo, forReading);
+            if (binding != null)
+                return binding;
+        }
+
         if (format.isOneOf(ResourceFormat.AUTO, ResourceFormat.JSON))
             return new CommandBindingJson(ctx, idEncoders, forReading, dataStore);
         else
@@ -181,7 +199,11 @@ public class CommandHandler extends BaseResourceHandler<BigId, ICommandData, Com
         
         var queryParams = ctx.getParameterMap();
         var filter = getFilter(ctx.getParentRef(), queryParams, 0, Long.MAX_VALUE);
-        var responseFormat = parseFormat(queryParams);
+        // default to the format already set by the transport layer, if any
+        // (e.g. MQTT ":data/<format-token>" subtopics); an explicit f= query
+        // param still takes precedence
+        var defaultFormat = ctx.getFormat() != null ? ctx.getFormat() : ResourceFormat.AUTO;
+        var responseFormat = parseFormat(queryParams, defaultFormat);
         ctx.setFormatOptions(responseFormat, parseSelectArg(queryParams));
         
         // continue when streaming actually starts

--- a/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/task/CommandStatusHandler.java
+++ b/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/task/CommandStatusHandler.java
@@ -146,7 +146,11 @@ public class CommandStatusHandler extends BaseResourceHandler<BigId, ICommandSta
         
         var queryParams = ctx.getParameterMap();
         var filter = getFilter(ctx.getParentRef(), queryParams, 0, Long.MAX_VALUE);
-        var responseFormat = parseFormat(queryParams);
+        // default to the format already set by the transport layer, if any
+        // (e.g. MQTT ":data/<format-token>" subtopics); an explicit f= query
+        // param still takes precedence
+        var defaultFormat = ctx.getFormat() != null ? ctx.getFormat() : ResourceFormat.AUTO;
+        var responseFormat = parseFormat(queryParams, defaultFormat);
         ctx.setFormatOptions(responseFormat, parseSelectArg(queryParams));
         
         // continue when streaming actually starts

--- a/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/task/CommandStreamBindingJson.java
+++ b/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/task/CommandStreamBindingJson.java
@@ -15,8 +15,11 @@ Copyright (C) 2020 Sensia Software LLC. All Rights Reserved.
 package org.sensorhub.impl.service.consys.task;
 
 import java.io.IOException;
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 import net.opengis.swe.v20.BinaryEncoding;
 import org.sensorhub.api.command.CommandStreamInfo;
 import org.sensorhub.api.command.ICommandStreamInfo;
@@ -27,6 +30,8 @@ import org.sensorhub.api.feature.FeatureId;
 import org.sensorhub.impl.service.consys.InvalidRequestException;
 import org.sensorhub.impl.service.consys.ResourceParseException;
 import org.sensorhub.impl.service.consys.SWECommonUtils;
+import org.sensorhub.impl.service.consys.ServiceErrors;
+import org.sensorhub.impl.service.consys.obs.CustomObsFormat;
 import org.sensorhub.impl.service.consys.resource.RequestContext;
 import org.sensorhub.impl.service.consys.resource.ResourceBindingJson;
 import org.sensorhub.impl.service.consys.resource.ResourceFormat;
@@ -37,6 +42,7 @@ import org.vast.swe.SWEHelper;
 import org.vast.swe.SWEStaxBindings;
 import org.vast.swe.json.SWEJsonStreamReader;
 import org.vast.swe.json.SWEJsonStreamWriter;
+import com.google.gson.JsonParser;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
@@ -47,18 +53,26 @@ public class CommandStreamBindingJson extends ResourceBindingJson<CommandStreamK
     final CommandStreamAssocs assocs;
     final String rootURL;
     final SWEStaxBindings sweBindings;
+    final Map<String, CustomObsFormat> customFormats;
     SWEJsonStreamReader sweReader;
     SWEJsonStreamWriter sweWriter;
-    
-    
+
+
     public CommandStreamBindingJson(RequestContext ctx, IdEncoders idEncoders, IObsSystemDatabase db, boolean forReading) throws IOException
     {
+        this(ctx, idEncoders, db, forReading, Collections.emptyMap());
+    }
+
+
+    public CommandStreamBindingJson(RequestContext ctx, IdEncoders idEncoders, IObsSystemDatabase db, boolean forReading, Map<String, CustomObsFormat> customFormats) throws IOException
+    {
         super(ctx, idEncoders, forReading);
-        
+
         this.assocs = new CommandStreamAssocs(db, idEncoders);
         this.rootURL = ctx.getApiRootURL();
         this.sweBindings = new SWEStaxBindings();
-        
+        this.customFormats = customFormats != null ? customFormats : Collections.emptyMap();
+
         if (forReading)
             this.sweReader = new SWEJsonStreamReader(reader);
         else
@@ -103,21 +117,35 @@ public class CommandStreamBindingJson extends ResourceBindingJson<CommandStreamK
                     sysRef = readFeatureRef(reader);
                 else if ("schema".equals(prop))
                 {
-                    reader.beginObject();
-                    
-                    /*// obsFormat must come first!
-                    if (!reader.nextName().equals("commandFormat"))
-                        throw new ResourceParseException(MISSING_PROP_ERROR_MSG + "schema/obsFormat");
-                    var obsFormat = reader.nextString();
-                    
-                    ResourceBindingJson<DataStreamKey, IDataStreamInfo> schemaBinding = null;
-                    if (ResourceFormat.JSON.getMimeType().equals(obsFormat))
-                        schemaBinding = new CommandStreamSchemaBindingJson(ctx, idEncoders, reader);
-                    
-                    if (schemaBinding == null)
-                        throw ServiceErrors.unsupportedFormat(obsFormat);*/
-                    var schemaBinding = new CommandStreamSchemaBindingJson(ctx, idEncoders, reader);
-                    csInfo = schemaBinding.deserialize(reader);
+                    // Buffer the schema object so commandFormat can be inspected
+                    // without destructively consuming the stream. This preserves
+                    // backward compatibility with bodies that omit commandFormat or
+                    // don't list it first (e.g. legacy "parametersSchema"-first), while
+                    // still letting a custom format (application/swe+proto) opt in.
+                    boolean wasLenient = reader.isLenient();
+                    reader.setLenient(true);
+                    var schemaObj = JsonParser.parseReader(reader).getAsJsonObject();
+                    reader.setLenient(wasLenient);
+
+                    var commandFormat = schemaObj.has("commandFormat")
+                        ? schemaObj.get("commandFormat").getAsString() : null;
+                    var bufReader = new JsonReader(new StringReader(schemaObj.toString()));
+
+                    ResourceBindingJson<CommandStreamKey, ICommandStreamInfo> schemaBinding;
+                    if (commandFormat != null && customFormats.containsKey(commandFormat))
+                    {
+                        var custom = customFormats.get(commandFormat).getCommandSchemaBinding(ctx, idEncoders, null);
+                        if (!(custom instanceof ResourceBindingJson))
+                            throw ServiceErrors.unsupportedFormat(commandFormat);
+                        schemaBinding = (ResourceBindingJson<CommandStreamKey, ICommandStreamInfo>) custom;
+                    }
+                    else
+                    {
+                        // unchanged default: SWE-Common JSON via the JSON binding
+                        schemaBinding = new CommandStreamSchemaBindingJson(ctx, idEncoders, bufReader);
+                    }
+
+                    csInfo = schemaBinding.deserialize(bufReader);
                 }
                 else
                     reader.skipValue();

--- a/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/task/CommandStreamHandler.java
+++ b/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/task/CommandStreamHandler.java
@@ -30,6 +30,7 @@ import org.sensorhub.impl.service.consys.HandlerContext;
 import org.sensorhub.impl.service.consys.ConSysApiSecurity;
 import org.sensorhub.impl.service.consys.ServiceErrors;
 import org.sensorhub.impl.service.consys.RestApiServlet.ResourcePermissions;
+import org.sensorhub.impl.service.consys.obs.CustomObsFormat;
 import org.sensorhub.impl.service.consys.resource.RequestContext;
 import org.sensorhub.impl.service.consys.resource.ResourceBinding;
 import org.sensorhub.impl.service.consys.resource.ResourceFormat;
@@ -46,14 +47,22 @@ public class CommandStreamHandler extends ResourceHandler<CommandStreamKey, ICom
     final IObsSystemDatabase db;
     final SystemDatabaseTransactionHandler transactionHandler;
     final CommandStreamEventsHandler eventsHandler;
-    
-    
+    final Map<String, CustomObsFormat> customFormats;
+
+
     public CommandStreamHandler(HandlerContext ctx, ResourcePermissions permissions)
+    {
+        this(ctx, permissions, java.util.Collections.emptyMap());
+    }
+
+
+    public CommandStreamHandler(HandlerContext ctx, ResourcePermissions permissions, Map<String, CustomObsFormat> customFormats)
     {
         super(ctx.getReadDb().getCommandStreamStore(), ctx.getCommandStreamIdEncoder(), ctx, permissions);
         this.db = ctx.getReadDb();
         this.transactionHandler = new SystemDatabaseTransactionHandler(ctx.getEventBus(), ctx.getWriteDb());
-        
+        this.customFormats = customFormats != null ? customFormats : java.util.Collections.emptyMap();
+
         this.eventsHandler = new CommandStreamEventsHandler(ctx, permissions);
         addSubResource(eventsHandler);
     }
@@ -70,7 +79,7 @@ public class CommandStreamHandler extends ResourceHandler<CommandStreamKey, ICom
             return new CommandStreamBindingHtml(ctx, idEncoders, db, true, title);
         }
         else if (format.isOneOf(ResourceFormat.AUTO, ResourceFormat.JSON))
-            return new CommandStreamBindingJson(ctx, idEncoders, db, forReading);
+            return new CommandStreamBindingJson(ctx, idEncoders, db, forReading, customFormats);
         else
             throw ServiceErrors.unsupportedFormat(format);
     }

--- a/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/task/CommandStreamSchemaHandler.java
+++ b/sensorhub-service-consys/src/main/java/org/sensorhub/impl/service/consys/task/CommandStreamSchemaHandler.java
@@ -25,6 +25,7 @@ import org.sensorhub.impl.service.consys.InvalidRequestException;
 import org.sensorhub.impl.service.consys.HandlerContext;
 import org.sensorhub.impl.service.consys.ServiceErrors;
 import org.sensorhub.impl.service.consys.RestApiServlet.ResourcePermissions;
+import org.sensorhub.impl.service.consys.obs.CustomObsFormat;
 import org.sensorhub.impl.service.consys.resource.RequestContext;
 import org.sensorhub.impl.service.consys.resource.ResourceBinding;
 import org.sensorhub.impl.service.consys.resource.ResourceFormat;
@@ -36,30 +37,52 @@ import org.vast.util.Asserts;
 public class CommandStreamSchemaHandler extends ResourceHandler<CommandStreamKey, ICommandStreamInfo, CommandStreamFilter, CommandStreamFilter.Builder, ICommandStreamStore>
 {
     public static final String[] NAMES = { "schema" };
-    
-    
+
+    final Map<String, CustomObsFormat> customFormats;
+
+
     public CommandStreamSchemaHandler(HandlerContext ctx, ResourcePermissions permissions)
     {
-        super(ctx.getReadDb().getCommandStreamStore(), ctx.getCommandStreamIdEncoder(), ctx, permissions);
+        this(ctx, permissions, java.util.Collections.emptyMap());
     }
-    
-    
+
+
+    public CommandStreamSchemaHandler(HandlerContext ctx, ResourcePermissions permissions, Map<String, CustomObsFormat> customFormats)
+    {
+        super(ctx.getReadDb().getCommandStreamStore(), ctx.getCommandStreamIdEncoder(), ctx, permissions);
+        this.customFormats = customFormats != null ? customFormats : java.util.Collections.emptyMap();
+    }
+
+
     @Override
     protected ResourceBinding<CommandStreamKey, ICommandStreamInfo> getBinding(RequestContext ctx, boolean forReading) throws IOException
     {
         var format = ctx.getFormat();
         if (!format.isOneOf(ResourceFormat.AUTO, ResourceFormat.JSON))
             throw ServiceErrors.unsupportedFormat(format);
-        
+
         // generate proper schema depending on command format
         var cmdFormat = parseFormat("commandFormat", ctx.getParameterMap());
         if (cmdFormat == null)
             cmdFormat = ResourceFormat.JSON;
-        
+
         if (format.equals(ResourceFormat.AUTO) && ctx.isBrowserHtmlRequest())
             return new CommandStreamBindingHtml(ctx, idEncoders);
         else if (cmdFormat.equals(ResourceFormat.JSON))
             return new CommandStreamSchemaBindingJson(ctx, idEncoders, forReading);
+        // custom command formats (e.g. application/swe+proto) provide their own
+        // schema binding — checked before the SWE_FORMAT_PREFIX branch since
+        // swe+proto also starts with "application/swe+"
+        else if (customFormats.containsKey(cmdFormat.getMimeType()))
+        {
+            var csInfo = dataStore.get(new CommandStreamKey(ctx.getParentRef().internalID));
+            if (csInfo == null)
+                throw ServiceErrors.notFound();
+            var binding = customFormats.get(cmdFormat.getMimeType()).getCommandSchemaBinding(ctx, idEncoders, csInfo);
+            if (binding == null)
+                throw ServiceErrors.unsupportedFormat(cmdFormat);
+            return binding;
+        }
         else if (cmdFormat.getMimeType().startsWith(ResourceFormat.SWE_FORMAT_PREFIX))
             return new CommandStreamSchemaBindingSweCommon(cmdFormat, ctx, idEncoders, forReading);
         else


### PR DESCRIPTION
This adds an extension for modules to add custom formats. In particular, swe+proto requires that other formats be exposed via the Connected Systems API module. See https://github.com/opensensorhub/osh-addons/pull/224