### PR TITLE
Bump version so socom builds get latest updates

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -1,6 +1,6 @@
 import java.nio.file.*;
 
-ext.oshCoreVersion = '2.0.1'
+ext.oshCoreVersion = '2.0.2'
 
 
 buildscript {


### PR DESCRIPTION
Bumping the version so that builds pull in the latest changes to osh-core modules